### PR TITLE
Adds test package

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,0 +1,54 @@
+// Copyright 2016 The go-libvirt Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package constants provides shared data for the libvirt package.
+package constants
+
+// magic program numbers
+// see: https://libvirt.org/git/?p=libvirt.git;a=blob_plain;f=src/remote/remote_protocol.x;hb=HEAD
+const (
+	ProgramVersion   = 1
+	ProgramRemote    = 0x20008086
+	ProgramQEMU      = 0x20008087
+	ProgramKeepAlive = 0x6b656570
+)
+
+// libvirt procedure identifiers
+const (
+	ProcConnectOpen           = 1
+	ProcConnectClose          = 2
+	ProcDomainLookupByName    = 23
+	ProcAuthList              = 66
+	ProcConnectGetLibVersion  = 157
+	ProcConnectListAllDomains = 273
+)
+
+// qemu procedure identifiers
+const (
+	QEMUDomainMonitor                       = 1
+	QEMUConnectDomainMonitorEventRegister   = 4
+	QEMUConnectDomainMonitorEventDeregister = 5
+	QEMUDomainMonitorEvent                  = 6
+)
+
+const (
+	// PacketLengthSize is the packet length, in bytes.
+	PacketLengthSize = 4
+
+	// HeaderSize is the packet header size, in bytes.
+	HeaderSize = 24
+
+	// UUIDSize is the length of a UUID, in bytes.
+	UUIDSize = 16
+)

--- a/libvirt.go
+++ b/libvirt.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	"github.com/davecgh/go-xdr/xdr2"
+	"github.com/digitalocean/go-libvirt/internal/constants"
 )
 
 // ErrEventsNotSupported is returned by Events() if event streams
@@ -52,7 +53,7 @@ type Libvirt struct {
 // Domain represents a domain as seen by libvirt.
 type Domain struct {
 	Name string
-	UUID [uuidSize]byte
+	UUID [constants.UUIDSize]byte
 	ID   int
 }
 
@@ -108,7 +109,7 @@ func (l *Libvirt) Domains() ([]Domain, error) {
 		return nil, err
 	}
 
-	resp, err := l.request(procConnectListAllDomains, programRemote, &buf)
+	resp, err := l.request(constants.ProcConnectListAllDomains, constants.ProgramRemote, &buf)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +160,7 @@ func (l *Libvirt) Events(dom string) (<-chan DomainEvent, error) {
 		return nil, err
 	}
 
-	resp, err := l.request(qemuConnectDomainMonitorEventRegister, programQEMU, &buf)
+	resp, err := l.request(constants.QEMUConnectDomainMonitorEventRegister, constants.ProgramQEMU, &buf)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +219,7 @@ func (l *Libvirt) Run(dom string, cmd []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	resp, err := l.request(qemuDomainMonitor, programQEMU, &buf)
+	resp, err := l.request(constants.QEMUDomainMonitor, constants.ProgramQEMU, &buf)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +243,7 @@ func (l *Libvirt) Run(dom string, cmd []byte) ([]byte, error) {
 
 // Version returns the version of the libvirt daemon.
 func (l *Libvirt) Version() (string, error) {
-	resp, err := l.request(procConnectGetLibVersion, programRemote, nil)
+	resp, err := l.request(constants.ProcConnectGetLibVersion, constants.ProgramRemote, nil)
 	if err != nil {
 		return "", err
 	}
@@ -286,7 +287,7 @@ func (l *Libvirt) lookup(name string) (*Domain, error) {
 		return nil, err
 	}
 
-	resp, err := l.request(procDomainLookupByName, programRemote, &buf)
+	resp, err := l.request(constants.ProcDomainLookupByName, constants.ProgramRemote, &buf)
 	if err != nil {
 		return nil, err
 	}

--- a/libvirt_test.go
+++ b/libvirt_test.go
@@ -19,10 +19,12 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/digitalocean/go-libvirt/libvirttest"
 )
 
 func TestConnect(t *testing.T) {
-	conn := setupTest()
+	conn := libvirttest.New()
 	l := New(conn)
 
 	err := l.Connect()
@@ -32,7 +34,7 @@ func TestConnect(t *testing.T) {
 }
 
 func TestDisconnect(t *testing.T) {
-	conn := setupTest()
+	conn := libvirttest.New()
 	l := New(conn)
 
 	err := l.Disconnect()
@@ -42,7 +44,7 @@ func TestDisconnect(t *testing.T) {
 }
 
 func TestDomains(t *testing.T) {
-	conn := setupTest()
+	conn := libvirttest.New()
 	l := New(conn)
 
 	domains, err := l.Domains()
@@ -70,7 +72,7 @@ func TestDomains(t *testing.T) {
 }
 
 func TestEvents(t *testing.T) {
-	conn := setupTest()
+	conn := libvirttest.New()
 	l := New(conn)
 	done := make(chan struct{})
 
@@ -108,14 +110,14 @@ func TestEvents(t *testing.T) {
 	}()
 
 	// send an event to the listener goroutine
-	conn.test.Write(append(testEventHeader, testEvent...))
+	conn.Test.Write(append(testEventHeader, testEvent...))
 
 	// wait for completion
 	<-done
 }
 
 func TestRun(t *testing.T) {
-	conn := setupTest()
+	conn := libvirttest.New()
 	l := New(conn)
 
 	res, err := l.Run("test", []byte(`{"query-version"}`))
@@ -147,7 +149,7 @@ func TestRun(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	conn := setupTest()
+	conn := libvirttest.New()
 	l := New(conn)
 
 	version, err := l.Version()

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -20,11 +20,13 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-xdr/xdr2"
+	"github.com/digitalocean/go-libvirt/internal/constants"
+	"github.com/digitalocean/go-libvirt/libvirttest"
 )
 
 var (
 	// dc229f87d4de47198cfd2e21c6105b01
-	testUUID = [uuidSize]byte{
+	testUUID = [constants.UUIDSize]byte{
 		0xdc, 0x22, 0x9f, 0x87, 0xd4, 0xde, 0x47, 0x19,
 		0x8c, 0xfd, 0x2e, 0x21, 0xc6, 0x10, 0x5b, 0x01,
 	}
@@ -118,16 +120,16 @@ func TestExtractHeader(t *testing.T) {
 		t.Error(err)
 	}
 
-	if h.Program != programRemote {
-		t.Errorf("expected Program %q, got %q", programRemote, h.Program)
+	if h.Program != constants.ProgramRemote {
+		t.Errorf("expected Program %q, got %q", constants.ProgramRemote, h.Program)
 	}
 
-	if h.Version != programVersion {
-		t.Errorf("expected version %q, got %q", programVersion, h.Version)
+	if h.Version != constants.ProgramVersion {
+		t.Errorf("expected version %q, got %q", constants.ProgramVersion, h.Version)
 	}
 
-	if h.Procedure != procConnectOpen {
-		t.Errorf("expected procedure %q, got %q", procConnectOpen, h.Procedure)
+	if h.Procedure != constants.ProcConnectOpen {
+		t.Errorf("expected procedure %q, got %q", constants.ProcConnectOpen, h.Procedure)
 	}
 
 	if h.Type != Call {
@@ -270,7 +272,7 @@ func TestAddStream(t *testing.T) {
 func TestRemoveStream(t *testing.T) {
 	id := uint32(1)
 
-	conn := setupTest()
+	conn := libvirttest.New()
 	l := New(conn)
 	l.events[id] = make(chan *DomainEvent)
 
@@ -328,7 +330,7 @@ func TestLookup(t *testing.T) {
 	c := make(chan response)
 	name := "test"
 
-	conn := setupTest()
+	conn := libvirttest.New()
 	l := New(conn)
 
 	l.register(id, c)


### PR DESCRIPTION
This splits out the mock libvirt server for testing within other packages. Constants from the main libvirt package have been moved to a separate package, constants, for shared access.