### PR TITLE
migrate: insert required request structure padding

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -277,12 +277,14 @@ func (l *Libvirt) Migrate(dom string, dest string, flags MigrateFlags) error {
 	// For now, using the same zero'd values as done by virsh will be Good Enough.
 	payload := struct {
 		Domain           Domain
+		Padding          [4]byte
 		DestinationURI   string
 		RemoteParameters uint32
 		CookieIn         uint32
 		Flags            MigrateFlags
 	}{
 		Domain:           *d,
+		Padding:          [4]byte{0x0, 0x0, 0x0, 0x1},
 		DestinationURI:   dest,
 		RemoteParameters: 0,
 		CookieIn:         0,


### PR DESCRIPTION
Further testing reveals we need some additional padding on the request passed to libvirt when performing migrations. I believe this is due to the structure alignment normally provided automatically by the compiler. We've seen this in a few other areas within the package as well.

In testing, this fixes an error I was seeing: "Unable to decode message payload", returned from libvirt when performing migrations.