### PR TITLE
ci: install libvirt for integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,45 @@
 language: go
+os: linux
+dist: trusty
+sudo: require
+
 go:
   - 1.7
+
+env:
+  - LIBVIRT=1.2.2  EXT=gz
+  - LIBVIRT=2.3.0  EXT=xz
+
 before_install:
   - go get github.com/golang/lint/golint
+
+install:
+  # credit here goes to the go-libvirt authors,
+  # see: https://github.com/rgbkrk/libvirt-go/blob/master/.travis.yml
+  - sudo apt-get -qqy build-dep libvirt
+  - sudo apt-get -qqy install curl qemu-system-x86
+  - sudo mkdir -p /usr/src && sudo chown $(id -u) /usr/src
+  - curl -O -s https://libvirt.org/sources/libvirt-${LIBVIRT}.tar.${EXT}
+  - tar -C /usr/src -xf libvirt-${LIBVIRT}.tar.${EXT}
+  - pushd /usr/src/libvirt-${LIBVIRT}
+  - |
+        ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc \
+                    --without-polkit \
+                    --without-esx --without-vbox --without-xen --without-libxl --without-lxc \
+                    --with-qemu
+  - make
+  - sudo make install
+  - popd
+  - sudo libvirtd -d -l -f libvirtd.conf
+  - sudo virtlogd -d || true
+
 before_script:
   - go get -d ./...
+
 script:
+  - virsh list
   - ./scripts/licensecheck.sh
   - go build ./...
   - golint -set_exit_status ./...
   - go vet ./...
-  - go test -v ./...
+  - go test -v -tags=integration ./...

--- a/libvirt_integration_test.go
+++ b/libvirt_integration_test.go
@@ -1,0 +1,50 @@
+// Copyright 2016 The go-libvirt Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build integration
+
+package libvirt
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+const testAddr = "127.0.0.1:16509"
+
+func TestConnectIntegration(t *testing.T) {
+	l := New(testConn(t))
+	defer l.Disconnect()
+
+	if err := l.Connect(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestDisconnectIntegration(t *testing.T) {
+	l := New(testConn(t))
+	if err := l.Disconnect(); err != nil {
+		t.Error(err)
+	}
+}
+
+func testConn(t *testing.T) net.Conn {
+	conn, err := net.DialTimeout("tcp", testAddr, time.Second*2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return conn
+}

--- a/libvirtd.conf
+++ b/libvirtd.conf
@@ -1,0 +1,7 @@
+# libvirtd configuration for travis-ci
+listen_tls = 0
+listen_tcp = 1
+tcp_port = "16509"
+listen_addr = "127.0.0.1"
+auth_unix_rw = "none"
+auth_tcp = "none"


### PR DESCRIPTION
This modifies the travis-ci configuration to build and install libvirt `1.2.2` and `2.3.0` for integration testing. Simple integration tests have been included for `Connect()` and `Disconnect()`.

Fixes #12 