### PR TITLE
Adds Capabilities()

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -38,6 +38,7 @@ const (
 const (
 	ProcConnectOpen              = 1
 	ProcConnectClose             = 2
+	ProcConnectGetCapabilties    = 7
 	ProcDomainGetXMLDesc         = 14
 	ProcDomainLookupByName       = 23
 	ProcAuthList                 = 66

--- a/libvirt.go
+++ b/libvirt.go
@@ -170,6 +170,24 @@ const (
 	DestroyFlagGraceful
 )
 
+// Capabilities returns an XML document describing the host's capabilties.
+func (l *Libvirt) Capabilities() ([]byte, error) {
+	resp, err := l.request(constants.ProcConnectGetCapabilties, constants.ProgramRemote, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := <-resp
+	if r.Status != StatusOK {
+		return nil, decodeError(r.Payload)
+	}
+
+	dec := xdr.NewDecoder(bytes.NewReader(r.Payload))
+	caps, _, err := dec.DecodeString()
+
+	return []byte(caps), err
+}
+
 // Connect establishes communication with the libvirt server.
 // The underlying libvirt socket connection must be previously established.
 func (l *Libvirt) Connect() error {

--- a/libvirt_integration_test.go
+++ b/libvirt_integration_test.go
@@ -41,6 +41,35 @@ func TestDisconnectIntegration(t *testing.T) {
 	}
 }
 
+func TestCapabilities(t *testing.T) {
+	l := New(testConn(t))
+	defer l.Disconnect()
+
+	if err := l.Connect(); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := l.Capabilities()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// verify UUID exists within returned XML
+	var caps struct {
+		Host struct {
+			UUID string `xml:"uuid"`
+		} `xml:"host"`
+	}
+
+	if err := xml.Unmarshal(resp, &caps); err != nil {
+		t.Fatal(err)
+	}
+
+	if caps.Host.UUID == "" {
+		t.Error("expected capabilities to contain a UUID")
+	}
+}
+
 func TestXMLIntegration(t *testing.T) {
 	l := New(testConn(t))
 


### PR DESCRIPTION
This adds a new method, Capabilities(), which returns an XML definition of the hypervisor's system
capabilities, much like `virsh capabilities`.

I've only included integration tests for these two methods due to the large amount of data returned by the capabilities call.
