### PR TITLE
Adds support for dumping domain XML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,11 @@ install:
 
 before_script:
   - go get -d ./...
+  - sudo qemu-img create -f raw -o size=10M /var/lib/libvirt/images/test.raw
+  - sudo virsh define ./test-domain.xml
+  - sudo virsh start test
 
 script:
-  - virsh list
   - ./scripts/licensecheck.sh
   - go build ./...
   - golint -set_exit_status ./...

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -38,6 +38,7 @@ const (
 const (
 	ProcConnectOpen              = 1
 	ProcConnectClose             = 2
+	ProcDomainGetXMLDesc         = 14
 	ProcDomainLookupByName       = 23
 	ProcAuthList                 = 66
 	ProcConnectGetLibVersion     = 157

--- a/libvirt_integration_test.go
+++ b/libvirt_integration_test.go
@@ -17,6 +17,7 @@
 package libvirt
 
 import (
+	"encoding/xml"
 	"net"
 	"testing"
 	"time"
@@ -36,6 +37,26 @@ func TestConnectIntegration(t *testing.T) {
 func TestDisconnectIntegration(t *testing.T) {
 	l := New(testConn(t))
 	if err := l.Disconnect(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestXMLIntegration(t *testing.T) {
+	l := New(testConn(t))
+
+	if err := l.Connect(); err != nil {
+		t.Error(err)
+	}
+	defer l.Disconnect()
+
+	var flags DomainXMLFlags
+	data, err := l.XML("test", flags)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var v interface{}
+	if err := xml.Unmarshal(data, &v); err != nil {
 		t.Error(err)
 	}
 }

--- a/test-domain.xml
+++ b/test-domain.xml
@@ -1,0 +1,38 @@
+<!-- simple integration test domain for go-libvirt -->
+<domain type="qemu">
+  <name>test</name>
+  <currentMemory>1024</currentMemory>
+  <memory>1024</memory>
+  <uuid>afc2ef71-66e0-45a7-a5ec-d8ba1ea8177d</uuid>
+  <os>
+    <type arch='x86_64'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <features>
+    <acpi/><apic/><pae/>
+  </features>
+  <clock offset="utc"/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>restart</on_crash>
+  <vcpu>1</vcpu>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='raw'/>
+      <source file='/var/lib/libvirt/images/test.raw'/>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+    <disk type='block' device='cdrom'>
+      <target dev='hdc' bus='ide'/>
+      <readonly/>
+    </disk>
+    <input type='tablet' bus='usb'/>
+    <graphics type='vnc' port='-1'/>
+    <console type='pty'/>
+    <sound model='ac97'/>
+    <video>
+      <model type='cirrus'/>
+    </video>
+  </devices>
+</domain>


### PR DESCRIPTION
This adds support for dumping a domain's XML definition, akin to `virsh dumpxml <domain>`. The returned data is quite large so I've included an integration test rather than adding a huge blob of hex to `libvirttest`.