### PR TITLE
Add String() method to DomainMemoryStatTag type

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -362,6 +362,35 @@ const (
 	DomainMemoryStatTagNr
 )
 
+func (d DomainMemoryStatTag) String() string {
+	switch d {
+	case DomainMemoryStatTagSwapIn:
+		return "swap_in"
+	case DomainMemoryStatTagSwapOut:
+		return "swap_out"
+	case DomainMemoryStatTagMajorFault:
+		return "major_fault"
+	case DomainMemoryStatTagMinorFault:
+		return "minor_fault"
+	case DomainMemoryStatTagUnused:
+		return "unused"
+	case DomainMemoryStatTagAvailable:
+		return "available"
+	case DomainMemoryStatTagActualBalloon:
+		return "actual_ballon"
+	case DomainMemoryStatTagRss:
+		return "rss"
+	case DomainMemoryStatTagUsable:
+		return "usable"
+	case DomainMemoryStatTagLastUpdate:
+		return "last_update"
+	case DomainMemoryStatTagNr:
+		return "nr"
+	}
+
+	return "unknown"
+}
+
 // DomainMemoryStat specifies memory stats of the domain
 type DomainMemoryStat struct {
 	Tag DomainMemoryStatTag


### PR DESCRIPTION
Just to add a String() method. It will be useful for collect metrics.