### PR TITLE
prevent connection write collisions

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -39,6 +39,7 @@ type Libvirt struct {
 	conn net.Conn
 	r    *bufio.Reader
 	w    *bufio.Writer
+	mu   *sync.Mutex
 
 	// method callbacks
 	cm        sync.Mutex
@@ -809,6 +810,7 @@ func New(conn net.Conn) *Libvirt {
 		s:         0,
 		r:         bufio.NewReader(conn),
 		w:         bufio.NewWriter(conn),
+		mu:        &sync.Mutex{},
 		callbacks: make(map[uint32]chan response),
 		events:    make(map[uint32]chan *DomainEvent),
 	}

--- a/rpc.go
+++ b/rpc.go
@@ -338,6 +338,8 @@ func (l *Libvirt) request(proc uint32, program uint32, payload *bytes.Buffer) (<
 	}
 
 	// write header
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	err := binary.Write(l.w, binary.BigEndian, p)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When multiple calls are made on the same connection, it's possible for the writes to collide with each other. This adds a write mutex when communicating with the libvirt daemon.

This surfaces as an error from libvirt: `short write`. Reproduced with the following example:

```go
package main

import (
	"log"
	"net"
	"sync"
	"time"

	"github.com/digitalocean/go-libvirt"
)

func main() {
	c, err := net.DialTimeout("tcp", "127.0.0.1:16509", 2*time.Second)
	if err != nil {
		log.Fatalf("failed to dial libvirt: %v", err)
	}

	l := libvirt.New(c)
	if err := l.Connect(); err != nil {
		log.Fatalf("failed to connect: %v", err)
	}
	defer l.Disconnect()

	count := 10
	wg := sync.WaitGroup{}
	wg.Add(count)
	start := make(chan struct{})
	for i := 0; i < count; i++ {
		go func(n int) {
			defer wg.Done()
			<-start

			doms, err := l.Domains()
			if err != nil {
				log.Printf("error from %d: %v", n, err)
				return
			}

			log.Printf("found %d domains", len(doms))
		}(i)
	}

	close(start)
	wg.Wait()
}

```

Bug:

```
$ ./test 
2017/12/07 09:33:50 error from 2: short write
2017/12/07 09:33:50 error from 0: short write
2017/12/07 09:33:50 error from 4: short write
2017/12/07 09:33:50 error from 7: short write
2017/12/07 09:33:50 error from 3: short write
2017/12/07 09:33:50 error from 9: short write
2017/12/07 09:33:50 error from 8: short write
2017/12/07 09:33:50 error from 5: short write
2017/12/07 09:33:50 error from 6: short write
```

Post-fix with mutex:

```
$ ./test 
2017/12/07 09:34:41 found 1 domains
2017/12/07 09:34:41 found 1 domains
2017/12/07 09:34:41 found 1 domains
2017/12/07 09:34:41 found 1 domains
2017/12/07 09:34:41 found 1 domains
2017/12/07 09:34:41 found 1 domains
2017/12/07 09:34:41 found 1 domains
2017/12/07 09:34:41 found 1 domains
2017/12/07 09:34:41 found 1 domains
2017/12/07 09:34:41 found 1 domains
```