### PR TITLE
adds missing mutex around callback map

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -208,7 +208,9 @@ func (l *Libvirt) listen() {
 
 // callback sends rpc responses to their respective caller.
 func (l *Libvirt) callback(id uint32, res response) {
+	l.cm.Lock()
 	c, ok := l.callbacks[id]
+	l.cm.Unlock()
 	if ok {
 		c <- res
 	}


### PR DESCRIPTION
We were missing a mutex when retrieving the caller in callback().
Triggered a test failure here: https://travis-ci.org/digitalocean/go-libvirt/jobs/317051310