### PR TITLE
Geoff/c for go flags

### DIFF
--- a/const.gen.go
+++ b/const.gen.go
@@ -153,275 +153,277 @@ const (
 	MigrateParamAutoConvergeInitial = "auto_converge.initial"
 	// MigrateParamAutoConvergeIncrement as defined in libvirt/libvirt-domain.h:1009
 	MigrateParamAutoConvergeIncrement = "auto_converge.increment"
-	// DomainCPUStatsCputime as defined in libvirt/libvirt-domain.h:1252
+	// DomainCPUStatsCputime as defined in libvirt/libvirt-domain.h:1262
 	DomainCPUStatsCputime = "cpu_time"
-	// DomainCPUStatsUsertime as defined in libvirt/libvirt-domain.h:1258
+	// DomainCPUStatsUsertime as defined in libvirt/libvirt-domain.h:1268
 	DomainCPUStatsUsertime = "user_time"
-	// DomainCPUStatsSystemtime as defined in libvirt/libvirt-domain.h:1264
+	// DomainCPUStatsSystemtime as defined in libvirt/libvirt-domain.h:1274
 	DomainCPUStatsSystemtime = "system_time"
-	// DomainCPUStatsVcputime as defined in libvirt/libvirt-domain.h:1271
+	// DomainCPUStatsVcputime as defined in libvirt/libvirt-domain.h:1281
 	DomainCPUStatsVcputime = "vcpu_time"
-	// DomainBlkioWeight as defined in libvirt/libvirt-domain.h:1300
+	// DomainBlkioWeight as defined in libvirt/libvirt-domain.h:1310
 	DomainBlkioWeight = "weight"
-	// DomainBlkioDeviceWeight as defined in libvirt/libvirt-domain.h:1310
+	// DomainBlkioDeviceWeight as defined in libvirt/libvirt-domain.h:1320
 	DomainBlkioDeviceWeight = "device_weight"
-	// DomainBlkioDeviceReadIops as defined in libvirt/libvirt-domain.h:1321
+	// DomainBlkioDeviceReadIops as defined in libvirt/libvirt-domain.h:1331
 	DomainBlkioDeviceReadIops = "device_read_iops_sec"
-	// DomainBlkioDeviceWriteIops as defined in libvirt/libvirt-domain.h:1332
+	// DomainBlkioDeviceWriteIops as defined in libvirt/libvirt-domain.h:1342
 	DomainBlkioDeviceWriteIops = "device_write_iops_sec"
-	// DomainBlkioDeviceReadBps as defined in libvirt/libvirt-domain.h:1343
+	// DomainBlkioDeviceReadBps as defined in libvirt/libvirt-domain.h:1353
 	DomainBlkioDeviceReadBps = "device_read_bytes_sec"
-	// DomainBlkioDeviceWriteBps as defined in libvirt/libvirt-domain.h:1354
+	// DomainBlkioDeviceWriteBps as defined in libvirt/libvirt-domain.h:1364
 	DomainBlkioDeviceWriteBps = "device_write_bytes_sec"
-	// DomainMemoryParamUnlimited as defined in libvirt/libvirt-domain.h:1373
+	// DomainMemoryParamUnlimited as defined in libvirt/libvirt-domain.h:1383
 	DomainMemoryParamUnlimited = 9007199254740991
-	// DomainMemoryHardLimit as defined in libvirt/libvirt-domain.h:1382
+	// DomainMemoryHardLimit as defined in libvirt/libvirt-domain.h:1392
 	DomainMemoryHardLimit = "hard_limit"
-	// DomainMemorySoftLimit as defined in libvirt/libvirt-domain.h:1391
+	// DomainMemorySoftLimit as defined in libvirt/libvirt-domain.h:1401
 	DomainMemorySoftLimit = "soft_limit"
-	// DomainMemoryMinGuarantee as defined in libvirt/libvirt-domain.h:1400
+	// DomainMemoryMinGuarantee as defined in libvirt/libvirt-domain.h:1410
 	DomainMemoryMinGuarantee = "min_guarantee"
-	// DomainMemorySwapHardLimit as defined in libvirt/libvirt-domain.h:1410
+	// DomainMemorySwapHardLimit as defined in libvirt/libvirt-domain.h:1420
 	DomainMemorySwapHardLimit = "swap_hard_limit"
-	// DomainNumaNodeset as defined in libvirt/libvirt-domain.h:1455
+	// DomainNumaNodeset as defined in libvirt/libvirt-domain.h:1465
 	DomainNumaNodeset = "numa_nodeset"
-	// DomainNumaMode as defined in libvirt/libvirt-domain.h:1463
+	// DomainNumaMode as defined in libvirt/libvirt-domain.h:1473
 	DomainNumaMode = "numa_mode"
-	// DomainBandwidthInAverage as defined in libvirt/libvirt-domain.h:1575
+	// DomainBandwidthInAverage as defined in libvirt/libvirt-domain.h:1585
 	DomainBandwidthInAverage = "inbound.average"
-	// DomainBandwidthInPeak as defined in libvirt/libvirt-domain.h:1582
+	// DomainBandwidthInPeak as defined in libvirt/libvirt-domain.h:1592
 	DomainBandwidthInPeak = "inbound.peak"
-	// DomainBandwidthInBurst as defined in libvirt/libvirt-domain.h:1589
+	// DomainBandwidthInBurst as defined in libvirt/libvirt-domain.h:1599
 	DomainBandwidthInBurst = "inbound.burst"
-	// DomainBandwidthInFloor as defined in libvirt/libvirt-domain.h:1596
+	// DomainBandwidthInFloor as defined in libvirt/libvirt-domain.h:1606
 	DomainBandwidthInFloor = "inbound.floor"
-	// DomainBandwidthOutAverage as defined in libvirt/libvirt-domain.h:1603
+	// DomainBandwidthOutAverage as defined in libvirt/libvirt-domain.h:1613
 	DomainBandwidthOutAverage = "outbound.average"
-	// DomainBandwidthOutPeak as defined in libvirt/libvirt-domain.h:1610
+	// DomainBandwidthOutPeak as defined in libvirt/libvirt-domain.h:1620
 	DomainBandwidthOutPeak = "outbound.peak"
-	// DomainBandwidthOutBurst as defined in libvirt/libvirt-domain.h:1617
+	// DomainBandwidthOutBurst as defined in libvirt/libvirt-domain.h:1627
 	DomainBandwidthOutBurst = "outbound.burst"
-	// PerfParamCmt as defined in libvirt/libvirt-domain.h:2073
+	// PerfParamCmt as defined in libvirt/libvirt-domain.h:2083
 	PerfParamCmt = "cmt"
-	// PerfParamMbmt as defined in libvirt/libvirt-domain.h:2084
+	// PerfParamMbmt as defined in libvirt/libvirt-domain.h:2094
 	PerfParamMbmt = "mbmt"
-	// PerfParamMbml as defined in libvirt/libvirt-domain.h:2094
+	// PerfParamMbml as defined in libvirt/libvirt-domain.h:2104
 	PerfParamMbml = "mbml"
-	// PerfParamCacheMisses as defined in libvirt/libvirt-domain.h:2104
+	// PerfParamCacheMisses as defined in libvirt/libvirt-domain.h:2114
 	PerfParamCacheMisses = "cache_misses"
-	// PerfParamCacheReferences as defined in libvirt/libvirt-domain.h:2114
+	// PerfParamCacheReferences as defined in libvirt/libvirt-domain.h:2124
 	PerfParamCacheReferences = "cache_references"
-	// PerfParamInstructions as defined in libvirt/libvirt-domain.h:2124
+	// PerfParamInstructions as defined in libvirt/libvirt-domain.h:2134
 	PerfParamInstructions = "instructions"
-	// PerfParamCPUCycles as defined in libvirt/libvirt-domain.h:2134
+	// PerfParamCPUCycles as defined in libvirt/libvirt-domain.h:2144
 	PerfParamCPUCycles = "cpu_cycles"
-	// PerfParamBranchInstructions as defined in libvirt/libvirt-domain.h:2144
+	// PerfParamBranchInstructions as defined in libvirt/libvirt-domain.h:2154
 	PerfParamBranchInstructions = "branch_instructions"
-	// PerfParamBranchMisses as defined in libvirt/libvirt-domain.h:2154
+	// PerfParamBranchMisses as defined in libvirt/libvirt-domain.h:2164
 	PerfParamBranchMisses = "branch_misses"
-	// PerfParamBusCycles as defined in libvirt/libvirt-domain.h:2164
+	// PerfParamBusCycles as defined in libvirt/libvirt-domain.h:2174
 	PerfParamBusCycles = "bus_cycles"
-	// PerfParamStalledCyclesFrontend as defined in libvirt/libvirt-domain.h:2175
+	// PerfParamStalledCyclesFrontend as defined in libvirt/libvirt-domain.h:2185
 	PerfParamStalledCyclesFrontend = "stalled_cycles_frontend"
-	// PerfParamStalledCyclesBackend as defined in libvirt/libvirt-domain.h:2186
+	// PerfParamStalledCyclesBackend as defined in libvirt/libvirt-domain.h:2196
 	PerfParamStalledCyclesBackend = "stalled_cycles_backend"
-	// PerfParamRefCPUCycles as defined in libvirt/libvirt-domain.h:2197
+	// PerfParamRefCPUCycles as defined in libvirt/libvirt-domain.h:2207
 	PerfParamRefCPUCycles = "ref_cpu_cycles"
-	// PerfParamCPUClock as defined in libvirt/libvirt-domain.h:2208
+	// PerfParamCPUClock as defined in libvirt/libvirt-domain.h:2218
 	PerfParamCPUClock = "cpu_clock"
-	// PerfParamTaskClock as defined in libvirt/libvirt-domain.h:2219
+	// PerfParamTaskClock as defined in libvirt/libvirt-domain.h:2229
 	PerfParamTaskClock = "task_clock"
-	// PerfParamPageFaults as defined in libvirt/libvirt-domain.h:2229
+	// PerfParamPageFaults as defined in libvirt/libvirt-domain.h:2239
 	PerfParamPageFaults = "page_faults"
-	// PerfParamContextSwitches as defined in libvirt/libvirt-domain.h:2239
+	// PerfParamContextSwitches as defined in libvirt/libvirt-domain.h:2249
 	PerfParamContextSwitches = "context_switches"
-	// PerfParamCPUMigrations as defined in libvirt/libvirt-domain.h:2249
+	// PerfParamCPUMigrations as defined in libvirt/libvirt-domain.h:2259
 	PerfParamCPUMigrations = "cpu_migrations"
-	// PerfParamPageFaultsMin as defined in libvirt/libvirt-domain.h:2259
+	// PerfParamPageFaultsMin as defined in libvirt/libvirt-domain.h:2269
 	PerfParamPageFaultsMin = "page_faults_min"
-	// PerfParamPageFaultsMaj as defined in libvirt/libvirt-domain.h:2269
+	// PerfParamPageFaultsMaj as defined in libvirt/libvirt-domain.h:2279
 	PerfParamPageFaultsMaj = "page_faults_maj"
-	// PerfParamAlignmentFaults as defined in libvirt/libvirt-domain.h:2279
+	// PerfParamAlignmentFaults as defined in libvirt/libvirt-domain.h:2289
 	PerfParamAlignmentFaults = "alignment_faults"
-	// PerfParamEmulationFaults as defined in libvirt/libvirt-domain.h:2289
+	// PerfParamEmulationFaults as defined in libvirt/libvirt-domain.h:2299
 	PerfParamEmulationFaults = "emulation_faults"
-	// DomainBlockCopyBandwidth as defined in libvirt/libvirt-domain.h:2453
+	// DomainBlockCopyBandwidth as defined in libvirt/libvirt-domain.h:2463
 	DomainBlockCopyBandwidth = "bandwidth"
-	// DomainBlockCopyGranularity as defined in libvirt/libvirt-domain.h:2464
+	// DomainBlockCopyGranularity as defined in libvirt/libvirt-domain.h:2474
 	DomainBlockCopyGranularity = "granularity"
-	// DomainBlockCopyBufSize as defined in libvirt/libvirt-domain.h:2473
+	// DomainBlockCopyBufSize as defined in libvirt/libvirt-domain.h:2483
 	DomainBlockCopyBufSize = "buf-size"
-	// DomainBlockIotuneTotalBytesSec as defined in libvirt/libvirt-domain.h:2514
+	// DomainBlockIotuneTotalBytesSec as defined in libvirt/libvirt-domain.h:2524
 	DomainBlockIotuneTotalBytesSec = "total_bytes_sec"
-	// DomainBlockIotuneReadBytesSec as defined in libvirt/libvirt-domain.h:2522
+	// DomainBlockIotuneReadBytesSec as defined in libvirt/libvirt-domain.h:2532
 	DomainBlockIotuneReadBytesSec = "read_bytes_sec"
-	// DomainBlockIotuneWriteBytesSec as defined in libvirt/libvirt-domain.h:2530
+	// DomainBlockIotuneWriteBytesSec as defined in libvirt/libvirt-domain.h:2540
 	DomainBlockIotuneWriteBytesSec = "write_bytes_sec"
-	// DomainBlockIotuneTotalIopsSec as defined in libvirt/libvirt-domain.h:2538
+	// DomainBlockIotuneTotalIopsSec as defined in libvirt/libvirt-domain.h:2548
 	DomainBlockIotuneTotalIopsSec = "total_iops_sec"
-	// DomainBlockIotuneReadIopsSec as defined in libvirt/libvirt-domain.h:2546
+	// DomainBlockIotuneReadIopsSec as defined in libvirt/libvirt-domain.h:2556
 	DomainBlockIotuneReadIopsSec = "read_iops_sec"
-	// DomainBlockIotuneWriteIopsSec as defined in libvirt/libvirt-domain.h:2553
+	// DomainBlockIotuneWriteIopsSec as defined in libvirt/libvirt-domain.h:2563
 	DomainBlockIotuneWriteIopsSec = "write_iops_sec"
-	// DomainBlockIotuneTotalBytesSecMax as defined in libvirt/libvirt-domain.h:2561
+	// DomainBlockIotuneTotalBytesSecMax as defined in libvirt/libvirt-domain.h:2571
 	DomainBlockIotuneTotalBytesSecMax = "total_bytes_sec_max"
-	// DomainBlockIotuneReadBytesSecMax as defined in libvirt/libvirt-domain.h:2569
+	// DomainBlockIotuneReadBytesSecMax as defined in libvirt/libvirt-domain.h:2579
 	DomainBlockIotuneReadBytesSecMax = "read_bytes_sec_max"
-	// DomainBlockIotuneWriteBytesSecMax as defined in libvirt/libvirt-domain.h:2577
+	// DomainBlockIotuneWriteBytesSecMax as defined in libvirt/libvirt-domain.h:2587
 	DomainBlockIotuneWriteBytesSecMax = "write_bytes_sec_max"
-	// DomainBlockIotuneTotalIopsSecMax as defined in libvirt/libvirt-domain.h:2585
+	// DomainBlockIotuneTotalIopsSecMax as defined in libvirt/libvirt-domain.h:2595
 	DomainBlockIotuneTotalIopsSecMax = "total_iops_sec_max"
-	// DomainBlockIotuneReadIopsSecMax as defined in libvirt/libvirt-domain.h:2593
+	// DomainBlockIotuneReadIopsSecMax as defined in libvirt/libvirt-domain.h:2603
 	DomainBlockIotuneReadIopsSecMax = "read_iops_sec_max"
-	// DomainBlockIotuneWriteIopsSecMax as defined in libvirt/libvirt-domain.h:2600
+	// DomainBlockIotuneWriteIopsSecMax as defined in libvirt/libvirt-domain.h:2610
 	DomainBlockIotuneWriteIopsSecMax = "write_iops_sec_max"
-	// DomainBlockIotuneTotalBytesSecMaxLength as defined in libvirt/libvirt-domain.h:2608
+	// DomainBlockIotuneTotalBytesSecMaxLength as defined in libvirt/libvirt-domain.h:2618
 	DomainBlockIotuneTotalBytesSecMaxLength = "total_bytes_sec_max_length"
-	// DomainBlockIotuneReadBytesSecMaxLength as defined in libvirt/libvirt-domain.h:2616
+	// DomainBlockIotuneReadBytesSecMaxLength as defined in libvirt/libvirt-domain.h:2626
 	DomainBlockIotuneReadBytesSecMaxLength = "read_bytes_sec_max_length"
-	// DomainBlockIotuneWriteBytesSecMaxLength as defined in libvirt/libvirt-domain.h:2624
+	// DomainBlockIotuneWriteBytesSecMaxLength as defined in libvirt/libvirt-domain.h:2634
 	DomainBlockIotuneWriteBytesSecMaxLength = "write_bytes_sec_max_length"
-	// DomainBlockIotuneTotalIopsSecMaxLength as defined in libvirt/libvirt-domain.h:2632
+	// DomainBlockIotuneTotalIopsSecMaxLength as defined in libvirt/libvirt-domain.h:2642
 	DomainBlockIotuneTotalIopsSecMaxLength = "total_iops_sec_max_length"
-	// DomainBlockIotuneReadIopsSecMaxLength as defined in libvirt/libvirt-domain.h:2640
+	// DomainBlockIotuneReadIopsSecMaxLength as defined in libvirt/libvirt-domain.h:2650
 	DomainBlockIotuneReadIopsSecMaxLength = "read_iops_sec_max_length"
-	// DomainBlockIotuneWriteIopsSecMaxLength as defined in libvirt/libvirt-domain.h:2648
+	// DomainBlockIotuneWriteIopsSecMaxLength as defined in libvirt/libvirt-domain.h:2658
 	DomainBlockIotuneWriteIopsSecMaxLength = "write_iops_sec_max_length"
-	// DomainBlockIotuneSizeIopsSec as defined in libvirt/libvirt-domain.h:2655
+	// DomainBlockIotuneSizeIopsSec as defined in libvirt/libvirt-domain.h:2665
 	DomainBlockIotuneSizeIopsSec = "size_iops_sec"
-	// DomainBlockIotuneGroupName as defined in libvirt/libvirt-domain.h:2662
+	// DomainBlockIotuneGroupName as defined in libvirt/libvirt-domain.h:2672
 	DomainBlockIotuneGroupName = "group_name"
-	// DomainSendKeyMaxKeys as defined in libvirt/libvirt-domain.h:2743
+	// DomainSendKeyMaxKeys as defined in libvirt/libvirt-domain.h:2753
 	DomainSendKeyMaxKeys = 16
-	// DomainJobOperationStr as defined in libvirt/libvirt-domain.h:3155
+	// DomainJobOperationStr as defined in libvirt/libvirt-domain.h:3165
 	DomainJobOperationStr = "operation"
-	// DomainJobTimeElapsed as defined in libvirt/libvirt-domain.h:3165
+	// DomainJobTimeElapsed as defined in libvirt/libvirt-domain.h:3175
 	DomainJobTimeElapsed = "time_elapsed"
-	// DomainJobTimeElapsedNet as defined in libvirt/libvirt-domain.h:3175
+	// DomainJobTimeElapsedNet as defined in libvirt/libvirt-domain.h:3185
 	DomainJobTimeElapsedNet = "time_elapsed_net"
-	// DomainJobTimeRemaining as defined in libvirt/libvirt-domain.h:3185
+	// DomainJobTimeRemaining as defined in libvirt/libvirt-domain.h:3195
 	DomainJobTimeRemaining = "time_remaining"
-	// DomainJobDowntime as defined in libvirt/libvirt-domain.h:3195
+	// DomainJobDowntime as defined in libvirt/libvirt-domain.h:3205
 	DomainJobDowntime = "downtime"
-	// DomainJobDowntimeNet as defined in libvirt/libvirt-domain.h:3204
+	// DomainJobDowntimeNet as defined in libvirt/libvirt-domain.h:3214
 	DomainJobDowntimeNet = "downtime_net"
-	// DomainJobSetupTime as defined in libvirt/libvirt-domain.h:3213
+	// DomainJobSetupTime as defined in libvirt/libvirt-domain.h:3223
 	DomainJobSetupTime = "setup_time"
-	// DomainJobDataTotal as defined in libvirt/libvirt-domain.h:3228
+	// DomainJobDataTotal as defined in libvirt/libvirt-domain.h:3238
 	DomainJobDataTotal = "data_total"
-	// DomainJobDataProcessed as defined in libvirt/libvirt-domain.h:3238
+	// DomainJobDataProcessed as defined in libvirt/libvirt-domain.h:3248
 	DomainJobDataProcessed = "data_processed"
-	// DomainJobDataRemaining as defined in libvirt/libvirt-domain.h:3248
+	// DomainJobDataRemaining as defined in libvirt/libvirt-domain.h:3258
 	DomainJobDataRemaining = "data_remaining"
-	// DomainJobMemoryTotal as defined in libvirt/libvirt-domain.h:3258
+	// DomainJobMemoryTotal as defined in libvirt/libvirt-domain.h:3268
 	DomainJobMemoryTotal = "memory_total"
-	// DomainJobMemoryProcessed as defined in libvirt/libvirt-domain.h:3268
+	// DomainJobMemoryProcessed as defined in libvirt/libvirt-domain.h:3278
 	DomainJobMemoryProcessed = "memory_processed"
-	// DomainJobMemoryRemaining as defined in libvirt/libvirt-domain.h:3278
+	// DomainJobMemoryRemaining as defined in libvirt/libvirt-domain.h:3288
 	DomainJobMemoryRemaining = "memory_remaining"
-	// DomainJobMemoryConstant as defined in libvirt/libvirt-domain.h:3290
+	// DomainJobMemoryConstant as defined in libvirt/libvirt-domain.h:3300
 	DomainJobMemoryConstant = "memory_constant"
-	// DomainJobMemoryNormal as defined in libvirt/libvirt-domain.h:3300
+	// DomainJobMemoryNormal as defined in libvirt/libvirt-domain.h:3310
 	DomainJobMemoryNormal = "memory_normal"
-	// DomainJobMemoryNormalBytes as defined in libvirt/libvirt-domain.h:3310
+	// DomainJobMemoryNormalBytes as defined in libvirt/libvirt-domain.h:3320
 	DomainJobMemoryNormalBytes = "memory_normal_bytes"
-	// DomainJobMemoryBps as defined in libvirt/libvirt-domain.h:3318
+	// DomainJobMemoryBps as defined in libvirt/libvirt-domain.h:3328
 	DomainJobMemoryBps = "memory_bps"
-	// DomainJobMemoryDirtyRate as defined in libvirt/libvirt-domain.h:3326
+	// DomainJobMemoryDirtyRate as defined in libvirt/libvirt-domain.h:3336
 	DomainJobMemoryDirtyRate = "memory_dirty_rate"
-	// DomainJobMemoryIteration as defined in libvirt/libvirt-domain.h:3337
+	// DomainJobMemoryPageSize as defined in libvirt/libvirt-domain.h:3347
+	DomainJobMemoryPageSize = "memory_page_size"
+	// DomainJobMemoryIteration as defined in libvirt/libvirt-domain.h:3358
 	DomainJobMemoryIteration = "memory_iteration"
-	// DomainJobDiskTotal as defined in libvirt/libvirt-domain.h:3347
+	// DomainJobDiskTotal as defined in libvirt/libvirt-domain.h:3368
 	DomainJobDiskTotal = "disk_total"
-	// DomainJobDiskProcessed as defined in libvirt/libvirt-domain.h:3357
+	// DomainJobDiskProcessed as defined in libvirt/libvirt-domain.h:3378
 	DomainJobDiskProcessed = "disk_processed"
-	// DomainJobDiskRemaining as defined in libvirt/libvirt-domain.h:3367
+	// DomainJobDiskRemaining as defined in libvirt/libvirt-domain.h:3388
 	DomainJobDiskRemaining = "disk_remaining"
-	// DomainJobDiskBps as defined in libvirt/libvirt-domain.h:3375
+	// DomainJobDiskBps as defined in libvirt/libvirt-domain.h:3396
 	DomainJobDiskBps = "disk_bps"
-	// DomainJobCompressionCache as defined in libvirt/libvirt-domain.h:3384
+	// DomainJobCompressionCache as defined in libvirt/libvirt-domain.h:3405
 	DomainJobCompressionCache = "compression_cache"
-	// DomainJobCompressionBytes as defined in libvirt/libvirt-domain.h:3392
+	// DomainJobCompressionBytes as defined in libvirt/libvirt-domain.h:3413
 	DomainJobCompressionBytes = "compression_bytes"
-	// DomainJobCompressionPages as defined in libvirt/libvirt-domain.h:3400
+	// DomainJobCompressionPages as defined in libvirt/libvirt-domain.h:3421
 	DomainJobCompressionPages = "compression_pages"
-	// DomainJobCompressionCacheMisses as defined in libvirt/libvirt-domain.h:3409
+	// DomainJobCompressionCacheMisses as defined in libvirt/libvirt-domain.h:3430
 	DomainJobCompressionCacheMisses = "compression_cache_misses"
-	// DomainJobCompressionOverflow as defined in libvirt/libvirt-domain.h:3419
+	// DomainJobCompressionOverflow as defined in libvirt/libvirt-domain.h:3440
 	DomainJobCompressionOverflow = "compression_overflow"
-	// DomainJobAutoConvergeThrottle as defined in libvirt/libvirt-domain.h:3428
+	// DomainJobAutoConvergeThrottle as defined in libvirt/libvirt-domain.h:3449
 	DomainJobAutoConvergeThrottle = "auto_converge_throttle"
-	// DomainTunableCPUVcpupin as defined in libvirt/libvirt-domain.h:3981
+	// DomainTunableCPUVcpupin as defined in libvirt/libvirt-domain.h:4003
 	DomainTunableCPUVcpupin = "cputune.vcpupin%u"
-	// DomainTunableCPUEmulatorpin as defined in libvirt/libvirt-domain.h:3989
+	// DomainTunableCPUEmulatorpin as defined in libvirt/libvirt-domain.h:4011
 	DomainTunableCPUEmulatorpin = "cputune.emulatorpin"
-	// DomainTunableCPUIothreadspin as defined in libvirt/libvirt-domain.h:3998
+	// DomainTunableCPUIothreadspin as defined in libvirt/libvirt-domain.h:4020
 	DomainTunableCPUIothreadspin = "cputune.iothreadpin%u"
-	// DomainTunableCPUCpuShares as defined in libvirt/libvirt-domain.h:4006
+	// DomainTunableCPUCpuShares as defined in libvirt/libvirt-domain.h:4028
 	DomainTunableCPUCpuShares = "cputune.cpu_shares"
-	// DomainTunableCPUGlobalPeriod as defined in libvirt/libvirt-domain.h:4014
+	// DomainTunableCPUGlobalPeriod as defined in libvirt/libvirt-domain.h:4036
 	DomainTunableCPUGlobalPeriod = "cputune.global_period"
-	// DomainTunableCPUGlobalQuota as defined in libvirt/libvirt-domain.h:4022
+	// DomainTunableCPUGlobalQuota as defined in libvirt/libvirt-domain.h:4044
 	DomainTunableCPUGlobalQuota = "cputune.global_quota"
-	// DomainTunableCPUVCPUPeriod as defined in libvirt/libvirt-domain.h:4030
+	// DomainTunableCPUVCPUPeriod as defined in libvirt/libvirt-domain.h:4052
 	DomainTunableCPUVCPUPeriod = "cputune.vcpu_period"
-	// DomainTunableCPUVCPUQuota as defined in libvirt/libvirt-domain.h:4038
+	// DomainTunableCPUVCPUQuota as defined in libvirt/libvirt-domain.h:4060
 	DomainTunableCPUVCPUQuota = "cputune.vcpu_quota"
-	// DomainTunableCPUEmulatorPeriod as defined in libvirt/libvirt-domain.h:4047
+	// DomainTunableCPUEmulatorPeriod as defined in libvirt/libvirt-domain.h:4069
 	DomainTunableCPUEmulatorPeriod = "cputune.emulator_period"
-	// DomainTunableCPUEmulatorQuota as defined in libvirt/libvirt-domain.h:4056
+	// DomainTunableCPUEmulatorQuota as defined in libvirt/libvirt-domain.h:4078
 	DomainTunableCPUEmulatorQuota = "cputune.emulator_quota"
-	// DomainTunableCPUIothreadPeriod as defined in libvirt/libvirt-domain.h:4064
+	// DomainTunableCPUIothreadPeriod as defined in libvirt/libvirt-domain.h:4086
 	DomainTunableCPUIothreadPeriod = "cputune.iothread_period"
-	// DomainTunableCPUIothreadQuota as defined in libvirt/libvirt-domain.h:4072
+	// DomainTunableCPUIothreadQuota as defined in libvirt/libvirt-domain.h:4094
 	DomainTunableCPUIothreadQuota = "cputune.iothread_quota"
-	// DomainTunableBlkdevDisk as defined in libvirt/libvirt-domain.h:4080
+	// DomainTunableBlkdevDisk as defined in libvirt/libvirt-domain.h:4102
 	DomainTunableBlkdevDisk = "blkdeviotune.disk"
-	// DomainTunableBlkdevTotalBytesSec as defined in libvirt/libvirt-domain.h:4088
+	// DomainTunableBlkdevTotalBytesSec as defined in libvirt/libvirt-domain.h:4110
 	DomainTunableBlkdevTotalBytesSec = "blkdeviotune.total_bytes_sec"
-	// DomainTunableBlkdevReadBytesSec as defined in libvirt/libvirt-domain.h:4096
+	// DomainTunableBlkdevReadBytesSec as defined in libvirt/libvirt-domain.h:4118
 	DomainTunableBlkdevReadBytesSec = "blkdeviotune.read_bytes_sec"
-	// DomainTunableBlkdevWriteBytesSec as defined in libvirt/libvirt-domain.h:4104
+	// DomainTunableBlkdevWriteBytesSec as defined in libvirt/libvirt-domain.h:4126
 	DomainTunableBlkdevWriteBytesSec = "blkdeviotune.write_bytes_sec"
-	// DomainTunableBlkdevTotalIopsSec as defined in libvirt/libvirt-domain.h:4112
+	// DomainTunableBlkdevTotalIopsSec as defined in libvirt/libvirt-domain.h:4134
 	DomainTunableBlkdevTotalIopsSec = "blkdeviotune.total_iops_sec"
-	// DomainTunableBlkdevReadIopsSec as defined in libvirt/libvirt-domain.h:4120
+	// DomainTunableBlkdevReadIopsSec as defined in libvirt/libvirt-domain.h:4142
 	DomainTunableBlkdevReadIopsSec = "blkdeviotune.read_iops_sec"
-	// DomainTunableBlkdevWriteIopsSec as defined in libvirt/libvirt-domain.h:4128
+	// DomainTunableBlkdevWriteIopsSec as defined in libvirt/libvirt-domain.h:4150
 	DomainTunableBlkdevWriteIopsSec = "blkdeviotune.write_iops_sec"
-	// DomainTunableBlkdevTotalBytesSecMax as defined in libvirt/libvirt-domain.h:4136
+	// DomainTunableBlkdevTotalBytesSecMax as defined in libvirt/libvirt-domain.h:4158
 	DomainTunableBlkdevTotalBytesSecMax = "blkdeviotune.total_bytes_sec_max"
-	// DomainTunableBlkdevReadBytesSecMax as defined in libvirt/libvirt-domain.h:4144
+	// DomainTunableBlkdevReadBytesSecMax as defined in libvirt/libvirt-domain.h:4166
 	DomainTunableBlkdevReadBytesSecMax = "blkdeviotune.read_bytes_sec_max"
-	// DomainTunableBlkdevWriteBytesSecMax as defined in libvirt/libvirt-domain.h:4152
+	// DomainTunableBlkdevWriteBytesSecMax as defined in libvirt/libvirt-domain.h:4174
 	DomainTunableBlkdevWriteBytesSecMax = "blkdeviotune.write_bytes_sec_max"
-	// DomainTunableBlkdevTotalIopsSecMax as defined in libvirt/libvirt-domain.h:4160
+	// DomainTunableBlkdevTotalIopsSecMax as defined in libvirt/libvirt-domain.h:4182
 	DomainTunableBlkdevTotalIopsSecMax = "blkdeviotune.total_iops_sec_max"
-	// DomainTunableBlkdevReadIopsSecMax as defined in libvirt/libvirt-domain.h:4168
+	// DomainTunableBlkdevReadIopsSecMax as defined in libvirt/libvirt-domain.h:4190
 	DomainTunableBlkdevReadIopsSecMax = "blkdeviotune.read_iops_sec_max"
-	// DomainTunableBlkdevWriteIopsSecMax as defined in libvirt/libvirt-domain.h:4176
+	// DomainTunableBlkdevWriteIopsSecMax as defined in libvirt/libvirt-domain.h:4198
 	DomainTunableBlkdevWriteIopsSecMax = "blkdeviotune.write_iops_sec_max"
-	// DomainTunableBlkdevSizeIopsSec as defined in libvirt/libvirt-domain.h:4184
+	// DomainTunableBlkdevSizeIopsSec as defined in libvirt/libvirt-domain.h:4206
 	DomainTunableBlkdevSizeIopsSec = "blkdeviotune.size_iops_sec"
-	// DomainTunableBlkdevGroupName as defined in libvirt/libvirt-domain.h:4192
+	// DomainTunableBlkdevGroupName as defined in libvirt/libvirt-domain.h:4214
 	DomainTunableBlkdevGroupName = "blkdeviotune.group_name"
-	// DomainTunableBlkdevTotalBytesSecMaxLength as defined in libvirt/libvirt-domain.h:4201
+	// DomainTunableBlkdevTotalBytesSecMaxLength as defined in libvirt/libvirt-domain.h:4223
 	DomainTunableBlkdevTotalBytesSecMaxLength = "blkdeviotune.total_bytes_sec_max_length"
-	// DomainTunableBlkdevReadBytesSecMaxLength as defined in libvirt/libvirt-domain.h:4210
+	// DomainTunableBlkdevReadBytesSecMaxLength as defined in libvirt/libvirt-domain.h:4232
 	DomainTunableBlkdevReadBytesSecMaxLength = "blkdeviotune.read_bytes_sec_max_length"
-	// DomainTunableBlkdevWriteBytesSecMaxLength as defined in libvirt/libvirt-domain.h:4219
+	// DomainTunableBlkdevWriteBytesSecMaxLength as defined in libvirt/libvirt-domain.h:4241
 	DomainTunableBlkdevWriteBytesSecMaxLength = "blkdeviotune.write_bytes_sec_max_length"
-	// DomainTunableBlkdevTotalIopsSecMaxLength as defined in libvirt/libvirt-domain.h:4228
+	// DomainTunableBlkdevTotalIopsSecMaxLength as defined in libvirt/libvirt-domain.h:4250
 	DomainTunableBlkdevTotalIopsSecMaxLength = "blkdeviotune.total_iops_sec_max_length"
-	// DomainTunableBlkdevReadIopsSecMaxLength as defined in libvirt/libvirt-domain.h:4237
+	// DomainTunableBlkdevReadIopsSecMaxLength as defined in libvirt/libvirt-domain.h:4259
 	DomainTunableBlkdevReadIopsSecMaxLength = "blkdeviotune.read_iops_sec_max_length"
-	// DomainTunableBlkdevWriteIopsSecMaxLength as defined in libvirt/libvirt-domain.h:4246
+	// DomainTunableBlkdevWriteIopsSecMaxLength as defined in libvirt/libvirt-domain.h:4268
 	DomainTunableBlkdevWriteIopsSecMaxLength = "blkdeviotune.write_iops_sec_max_length"
-	// DomainSchedFieldLength as defined in libvirt/libvirt-domain.h:4534
+	// DomainSchedFieldLength as defined in libvirt/libvirt-domain.h:4556
 	DomainSchedFieldLength = 80
-	// DomainBlkioFieldLength as defined in libvirt/libvirt-domain.h:4578
+	// DomainBlkioFieldLength as defined in libvirt/libvirt-domain.h:4600
 	DomainBlkioFieldLength = 80
-	// DomainMemoryFieldLength as defined in libvirt/libvirt-domain.h:4622
+	// DomainMemoryFieldLength as defined in libvirt/libvirt-domain.h:4644
 	DomainMemoryFieldLength = 80
 )
 
@@ -775,10 +777,10 @@ const (
 	MigrateTLS              DomainMigrateFlags = 65536
 )
 
-// DomainShutdownFlagValues as declared in libvirt/libvirt-domain.h:1117
+// DomainShutdownFlagValues as declared in libvirt/libvirt-domain.h:1121
 type DomainShutdownFlagValues int32
 
-// DomainShutdownFlagValues enumeration from libvirt/libvirt-domain.h:1117
+// DomainShutdownFlagValues enumeration from libvirt/libvirt-domain.h:1121
 const (
 	DomainShutdownDefault      DomainShutdownFlagValues = iota
 	DomainShutdownAcpiPowerBtn DomainShutdownFlagValues = 1
@@ -788,10 +790,10 @@ const (
 	DomainShutdownParavirt     DomainShutdownFlagValues = 16
 )
 
-// DomainRebootFlagValues as declared in libvirt/libvirt-domain.h:1130
+// DomainRebootFlagValues as declared in libvirt/libvirt-domain.h:1134
 type DomainRebootFlagValues int32
 
-// DomainRebootFlagValues enumeration from libvirt/libvirt-domain.h:1130
+// DomainRebootFlagValues enumeration from libvirt/libvirt-domain.h:1134
 const (
 	DomainRebootDefault      DomainRebootFlagValues = iota
 	DomainRebootAcpiPowerBtn DomainRebootFlagValues = 1
@@ -801,29 +803,29 @@ const (
 	DomainRebootParavirt     DomainRebootFlagValues = 16
 )
 
-// DomainDestroyFlagsValues as declared in libvirt/libvirt-domain.h:1148
+// DomainDestroyFlagsValues as declared in libvirt/libvirt-domain.h:1152
 type DomainDestroyFlagsValues int32
 
-// DomainDestroyFlagsValues enumeration from libvirt/libvirt-domain.h:1148
+// DomainDestroyFlagsValues enumeration from libvirt/libvirt-domain.h:1152
 const (
 	DomainDestroyDefault  DomainDestroyFlagsValues = iota
 	DomainDestroyGraceful DomainDestroyFlagsValues = 1
 )
 
-// DomainSaveRestoreFlags as declared in libvirt/libvirt-domain.h:1180
+// DomainSaveRestoreFlags as declared in libvirt/libvirt-domain.h:1184
 type DomainSaveRestoreFlags int32
 
-// DomainSaveRestoreFlags enumeration from libvirt/libvirt-domain.h:1180
+// DomainSaveRestoreFlags enumeration from libvirt/libvirt-domain.h:1184
 const (
 	DomainSaveBypassCache DomainSaveRestoreFlags = 1
 	DomainSaveRunning     DomainSaveRestoreFlags = 2
 	DomainSavePaused      DomainSaveRestoreFlags = 4
 )
 
-// DomainMemoryModFlags as declared in libvirt/libvirt-domain.h:1429
+// DomainMemoryModFlags as declared in libvirt/libvirt-domain.h:1439
 type DomainMemoryModFlags int32
 
-// DomainMemoryModFlags enumeration from libvirt/libvirt-domain.h:1429
+// DomainMemoryModFlags enumeration from libvirt/libvirt-domain.h:1439
 const (
 	DomainMemCurrent DomainMemoryModFlags = iota
 	DomainMemLive    DomainMemoryModFlags = 1
@@ -831,30 +833,30 @@ const (
 	DomainMemMaximum DomainMemoryModFlags = 4
 )
 
-// DomainNumatuneMemMode as declared in libvirt/libvirt-domain.h:1447
+// DomainNumatuneMemMode as declared in libvirt/libvirt-domain.h:1457
 type DomainNumatuneMemMode int32
 
-// DomainNumatuneMemMode enumeration from libvirt/libvirt-domain.h:1447
+// DomainNumatuneMemMode enumeration from libvirt/libvirt-domain.h:1457
 const (
 	DomainNumatuneMemStrict     DomainNumatuneMemMode = iota
 	DomainNumatuneMemPreferred  DomainNumatuneMemMode = 1
 	DomainNumatuneMemInterleave DomainNumatuneMemMode = 2
 )
 
-// DomainMetadataType as declared in libvirt/libvirt-domain.h:1509
+// DomainMetadataType as declared in libvirt/libvirt-domain.h:1519
 type DomainMetadataType int32
 
-// DomainMetadataType enumeration from libvirt/libvirt-domain.h:1509
+// DomainMetadataType enumeration from libvirt/libvirt-domain.h:1519
 const (
 	DomainMetadataDescription DomainMetadataType = iota
 	DomainMetadataTitle       DomainMetadataType = 1
 	DomainMetadataElement     DomainMetadataType = 2
 )
 
-// DomainXMLFlags as declared in libvirt/libvirt-domain.h:1539
+// DomainXMLFlags as declared in libvirt/libvirt-domain.h:1549
 type DomainXMLFlags int32
 
-// DomainXMLFlags enumeration from libvirt/libvirt-domain.h:1539
+// DomainXMLFlags enumeration from libvirt/libvirt-domain.h:1549
 const (
 	DomainXMLSecure     DomainXMLFlags = 1
 	DomainXMLInactive   DomainXMLFlags = 2
@@ -862,35 +864,35 @@ const (
 	DomainXMLMigratable DomainXMLFlags = 8
 )
 
-// DomainBlockResizeFlags as declared in libvirt/libvirt-domain.h:1644
+// DomainBlockResizeFlags as declared in libvirt/libvirt-domain.h:1654
 type DomainBlockResizeFlags int32
 
-// DomainBlockResizeFlags enumeration from libvirt/libvirt-domain.h:1644
+// DomainBlockResizeFlags enumeration from libvirt/libvirt-domain.h:1654
 const (
 	DomainBlockResizeBytes DomainBlockResizeFlags = 1
 )
 
-// DomainMemoryFlags as declared in libvirt/libvirt-domain.h:1707
+// DomainMemoryFlags as declared in libvirt/libvirt-domain.h:1717
 type DomainMemoryFlags int32
 
-// DomainMemoryFlags enumeration from libvirt/libvirt-domain.h:1707
+// DomainMemoryFlags enumeration from libvirt/libvirt-domain.h:1717
 const (
 	MemoryVirtual  DomainMemoryFlags = 1
 	MemoryPhysical DomainMemoryFlags = 2
 )
 
-// DomainDefineFlags as declared in libvirt/libvirt-domain.h:1717
+// DomainDefineFlags as declared in libvirt/libvirt-domain.h:1727
 type DomainDefineFlags int32
 
-// DomainDefineFlags enumeration from libvirt/libvirt-domain.h:1717
+// DomainDefineFlags enumeration from libvirt/libvirt-domain.h:1727
 const (
 	DomainDefineValidate DomainDefineFlags = 1
 )
 
-// DomainUndefineFlagsValues as declared in libvirt/libvirt-domain.h:1741
+// DomainUndefineFlagsValues as declared in libvirt/libvirt-domain.h:1751
 type DomainUndefineFlagsValues int32
 
-// DomainUndefineFlagsValues enumeration from libvirt/libvirt-domain.h:1741
+// DomainUndefineFlagsValues enumeration from libvirt/libvirt-domain.h:1751
 const (
 	DomainUndefineManagedSave       DomainUndefineFlagsValues = 1
 	DomainUndefineSnapshotsMetadata DomainUndefineFlagsValues = 2
@@ -898,10 +900,10 @@ const (
 	DomainUndefineKeepNvram         DomainUndefineFlagsValues = 8
 )
 
-// ConnectListAllDomainsFlags as declared in libvirt/libvirt-domain.h:1777
+// ConnectListAllDomainsFlags as declared in libvirt/libvirt-domain.h:1787
 type ConnectListAllDomainsFlags int32
 
-// ConnectListAllDomainsFlags enumeration from libvirt/libvirt-domain.h:1777
+// ConnectListAllDomainsFlags enumeration from libvirt/libvirt-domain.h:1787
 const (
 	ConnectListDomainsActive        ConnectListAllDomainsFlags = 1
 	ConnectListDomainsInactive      ConnectListAllDomainsFlags = 2
@@ -919,20 +921,20 @@ const (
 	ConnectListDomainsNoSnapshot    ConnectListAllDomainsFlags = 8192
 )
 
-// VCPUState as declared in libvirt/libvirt-domain.h:1808
+// VCPUState as declared in libvirt/libvirt-domain.h:1818
 type VCPUState int32
 
-// VCPUState enumeration from libvirt/libvirt-domain.h:1808
+// VCPUState enumeration from libvirt/libvirt-domain.h:1818
 const (
 	VCPUOffline VCPUState = iota
 	VCPURunning VCPUState = 1
 	VCPUBlocked VCPUState = 2
 )
 
-// DomainVCPUFlags as declared in libvirt/libvirt-domain.h:1830
+// DomainVCPUFlags as declared in libvirt/libvirt-domain.h:1840
 type DomainVCPUFlags int32
 
-// DomainVCPUFlags enumeration from libvirt/libvirt-domain.h:1830
+// DomainVCPUFlags enumeration from libvirt/libvirt-domain.h:1840
 const (
 	DomainVCPUCurrent      DomainVCPUFlags = iota
 	DomainVCPULive         DomainVCPUFlags = 1
@@ -942,10 +944,10 @@ const (
 	DomainVCPUHotpluggable DomainVCPUFlags = 16
 )
 
-// DomainDeviceModifyFlags as declared in libvirt/libvirt-domain.h:2003
+// DomainDeviceModifyFlags as declared in libvirt/libvirt-domain.h:2013
 type DomainDeviceModifyFlags int32
 
-// DomainDeviceModifyFlags enumeration from libvirt/libvirt-domain.h:2003
+// DomainDeviceModifyFlags enumeration from libvirt/libvirt-domain.h:2013
 const (
 	DomainDeviceModifyCurrent DomainDeviceModifyFlags = iota
 	DomainDeviceModifyLive    DomainDeviceModifyFlags = 1
@@ -953,10 +955,10 @@ const (
 	DomainDeviceModifyForce   DomainDeviceModifyFlags = 4
 )
 
-// DomainStatsTypes as declared in libvirt/libvirt-domain.h:2031
+// DomainStatsTypes as declared in libvirt/libvirt-domain.h:2041
 type DomainStatsTypes int32
 
-// DomainStatsTypes enumeration from libvirt/libvirt-domain.h:2031
+// DomainStatsTypes enumeration from libvirt/libvirt-domain.h:2041
 const (
 	DomainStatsState     DomainStatsTypes = 1
 	DomainStatsCPUTotal  DomainStatsTypes = 2
@@ -967,10 +969,10 @@ const (
 	DomainStatsPerf      DomainStatsTypes = 64
 )
 
-// ConnectGetAllDomainStatsFlags as declared in libvirt/libvirt-domain.h:2047
+// ConnectGetAllDomainStatsFlags as declared in libvirt/libvirt-domain.h:2057
 type ConnectGetAllDomainStatsFlags int32
 
-// ConnectGetAllDomainStatsFlags enumeration from libvirt/libvirt-domain.h:2047
+// ConnectGetAllDomainStatsFlags enumeration from libvirt/libvirt-domain.h:2057
 const (
 	ConnectGetAllDomainsStatsActive       ConnectGetAllDomainStatsFlags = 1
 	ConnectGetAllDomainsStatsInactive     ConnectGetAllDomainStatsFlags = 2
@@ -984,10 +986,10 @@ const (
 	ConnectGetAllDomainsStatsEnforceStats ConnectGetAllDomainStatsFlags = -2147483648
 )
 
-// DomainBlockJobType as declared in libvirt/libvirt-domain.h:2331
+// DomainBlockJobType as declared in libvirt/libvirt-domain.h:2341
 type DomainBlockJobType int32
 
-// DomainBlockJobType enumeration from libvirt/libvirt-domain.h:2331
+// DomainBlockJobType enumeration from libvirt/libvirt-domain.h:2341
 const (
 	DomainBlockJobTypeUnknown      DomainBlockJobType = iota
 	DomainBlockJobTypePull         DomainBlockJobType = 1
@@ -996,43 +998,43 @@ const (
 	DomainBlockJobTypeActiveCommit DomainBlockJobType = 4
 )
 
-// DomainBlockJobAbortFlags as declared in libvirt/libvirt-domain.h:2343
+// DomainBlockJobAbortFlags as declared in libvirt/libvirt-domain.h:2353
 type DomainBlockJobAbortFlags int32
 
-// DomainBlockJobAbortFlags enumeration from libvirt/libvirt-domain.h:2343
+// DomainBlockJobAbortFlags enumeration from libvirt/libvirt-domain.h:2353
 const (
 	DomainBlockJobAbortAsync DomainBlockJobAbortFlags = 1
 	DomainBlockJobAbortPivot DomainBlockJobAbortFlags = 2
 )
 
-// DomainBlockJobInfoFlags as declared in libvirt/libvirt-domain.h:2352
+// DomainBlockJobInfoFlags as declared in libvirt/libvirt-domain.h:2362
 type DomainBlockJobInfoFlags int32
 
-// DomainBlockJobInfoFlags enumeration from libvirt/libvirt-domain.h:2352
+// DomainBlockJobInfoFlags enumeration from libvirt/libvirt-domain.h:2362
 const (
 	DomainBlockJobInfoBandwidthBytes DomainBlockJobInfoFlags = 1
 )
 
-// DomainBlockJobSetSpeedFlags as declared in libvirt/libvirt-domain.h:2381
+// DomainBlockJobSetSpeedFlags as declared in libvirt/libvirt-domain.h:2391
 type DomainBlockJobSetSpeedFlags int32
 
-// DomainBlockJobSetSpeedFlags enumeration from libvirt/libvirt-domain.h:2381
+// DomainBlockJobSetSpeedFlags enumeration from libvirt/libvirt-domain.h:2391
 const (
 	DomainBlockJobSpeedBandwidthBytes DomainBlockJobSetSpeedFlags = 1
 )
 
-// DomainBlockPullFlags as declared in libvirt/libvirt-domain.h:2391
+// DomainBlockPullFlags as declared in libvirt/libvirt-domain.h:2401
 type DomainBlockPullFlags int32
 
-// DomainBlockPullFlags enumeration from libvirt/libvirt-domain.h:2391
+// DomainBlockPullFlags enumeration from libvirt/libvirt-domain.h:2401
 const (
 	DomainBlockPullBandwidthBytes DomainBlockPullFlags = 64
 )
 
-// DomainBlockRebaseFlags as declared in libvirt/libvirt-domain.h:2415
+// DomainBlockRebaseFlags as declared in libvirt/libvirt-domain.h:2425
 type DomainBlockRebaseFlags int32
 
-// DomainBlockRebaseFlags enumeration from libvirt/libvirt-domain.h:2415
+// DomainBlockRebaseFlags enumeration from libvirt/libvirt-domain.h:2425
 const (
 	DomainBlockRebaseShallow        DomainBlockRebaseFlags = 1
 	DomainBlockRebaseReuseExt       DomainBlockRebaseFlags = 2
@@ -1043,20 +1045,20 @@ const (
 	DomainBlockRebaseBandwidthBytes DomainBlockRebaseFlags = 64
 )
 
-// DomainBlockCopyFlags as declared in libvirt/libvirt-domain.h:2434
+// DomainBlockCopyFlags as declared in libvirt/libvirt-domain.h:2444
 type DomainBlockCopyFlags int32
 
-// DomainBlockCopyFlags enumeration from libvirt/libvirt-domain.h:2434
+// DomainBlockCopyFlags enumeration from libvirt/libvirt-domain.h:2444
 const (
 	DomainBlockCopyShallow      DomainBlockCopyFlags = 1
 	DomainBlockCopyReuseExt     DomainBlockCopyFlags = 2
 	DomainBlockCopyTransientJob DomainBlockCopyFlags = 4
 )
 
-// DomainBlockCommitFlags as declared in libvirt/libvirt-domain.h:2499
+// DomainBlockCommitFlags as declared in libvirt/libvirt-domain.h:2509
 type DomainBlockCommitFlags int32
 
-// DomainBlockCommitFlags enumeration from libvirt/libvirt-domain.h:2499
+// DomainBlockCommitFlags enumeration from libvirt/libvirt-domain.h:2509
 const (
 	DomainBlockCommitShallow        DomainBlockCommitFlags = 1
 	DomainBlockCommitDelete         DomainBlockCommitFlags = 2
@@ -1065,20 +1067,20 @@ const (
 	DomainBlockCommitBandwidthBytes DomainBlockCommitFlags = 16
 )
 
-// DomainDiskErrorCode as declared in libvirt/libvirt-domain.h:2690
+// DomainDiskErrorCode as declared in libvirt/libvirt-domain.h:2700
 type DomainDiskErrorCode int32
 
-// DomainDiskErrorCode enumeration from libvirt/libvirt-domain.h:2690
+// DomainDiskErrorCode enumeration from libvirt/libvirt-domain.h:2700
 const (
 	DomainDiskErrorNone    DomainDiskErrorCode = iota
 	DomainDiskErrorUnspec  DomainDiskErrorCode = 1
 	DomainDiskErrorNoSpace DomainDiskErrorCode = 2
 )
 
-// KeycodeSet as declared in libvirt/libvirt-domain.h:2736
+// KeycodeSet as declared in libvirt/libvirt-domain.h:2746
 type KeycodeSet int32
 
-// KeycodeSet enumeration from libvirt/libvirt-domain.h:2736
+// KeycodeSet enumeration from libvirt/libvirt-domain.h:2746
 const (
 	KeycodeSetLinux  KeycodeSet = iota
 	KeycodeSetXt     KeycodeSet = 1
@@ -1092,10 +1094,10 @@ const (
 	KeycodeSetRfb    KeycodeSet = 9
 )
 
-// DomainProcessSignal as declared in libvirt/libvirt-domain.h:2838
+// DomainProcessSignal as declared in libvirt/libvirt-domain.h:2848
 type DomainProcessSignal int32
 
-// DomainProcessSignal enumeration from libvirt/libvirt-domain.h:2838
+// DomainProcessSignal enumeration from libvirt/libvirt-domain.h:2848
 const (
 	DomainProcessSignalNop    DomainProcessSignal = iota
 	DomainProcessSignalHup    DomainProcessSignal = 1
@@ -1164,10 +1166,10 @@ const (
 	DomainProcessSignalRt32   DomainProcessSignal = 64
 )
 
-// DomainEventType as declared in libvirt/libvirt-domain.h:2876
+// DomainEventType as declared in libvirt/libvirt-domain.h:2886
 type DomainEventType int32
 
-// DomainEventType enumeration from libvirt/libvirt-domain.h:2876
+// DomainEventType enumeration from libvirt/libvirt-domain.h:2886
 const (
 	DomainEventDefined     DomainEventType = iota
 	DomainEventUndefined   DomainEventType = 1
@@ -1180,10 +1182,10 @@ const (
 	DomainEventCrashed     DomainEventType = 8
 )
 
-// DomainEventDefinedDetailType as declared in libvirt/libvirt-domain.h:2892
+// DomainEventDefinedDetailType as declared in libvirt/libvirt-domain.h:2902
 type DomainEventDefinedDetailType int32
 
-// DomainEventDefinedDetailType enumeration from libvirt/libvirt-domain.h:2892
+// DomainEventDefinedDetailType enumeration from libvirt/libvirt-domain.h:2902
 const (
 	DomainEventDefinedAdded        DomainEventDefinedDetailType = iota
 	DomainEventDefinedUpdated      DomainEventDefinedDetailType = 1
@@ -1191,19 +1193,19 @@ const (
 	DomainEventDefinedFromSnapshot DomainEventDefinedDetailType = 3
 )
 
-// DomainEventUndefinedDetailType as declared in libvirt/libvirt-domain.h:2906
+// DomainEventUndefinedDetailType as declared in libvirt/libvirt-domain.h:2916
 type DomainEventUndefinedDetailType int32
 
-// DomainEventUndefinedDetailType enumeration from libvirt/libvirt-domain.h:2906
+// DomainEventUndefinedDetailType enumeration from libvirt/libvirt-domain.h:2916
 const (
 	DomainEventUndefinedRemoved DomainEventUndefinedDetailType = iota
 	DomainEventUndefinedRenamed DomainEventUndefinedDetailType = 1
 )
 
-// DomainEventStartedDetailType as declared in libvirt/libvirt-domain.h:2923
+// DomainEventStartedDetailType as declared in libvirt/libvirt-domain.h:2933
 type DomainEventStartedDetailType int32
 
-// DomainEventStartedDetailType enumeration from libvirt/libvirt-domain.h:2923
+// DomainEventStartedDetailType enumeration from libvirt/libvirt-domain.h:2933
 const (
 	DomainEventStartedBooted       DomainEventStartedDetailType = iota
 	DomainEventStartedMigrated     DomainEventStartedDetailType = 1
@@ -1212,10 +1214,10 @@ const (
 	DomainEventStartedWakeup       DomainEventStartedDetailType = 4
 )
 
-// DomainEventSuspendedDetailType as declared in libvirt/libvirt-domain.h:2944
+// DomainEventSuspendedDetailType as declared in libvirt/libvirt-domain.h:2954
 type DomainEventSuspendedDetailType int32
 
-// DomainEventSuspendedDetailType enumeration from libvirt/libvirt-domain.h:2944
+// DomainEventSuspendedDetailType enumeration from libvirt/libvirt-domain.h:2954
 const (
 	DomainEventSuspendedPaused         DomainEventSuspendedDetailType = iota
 	DomainEventSuspendedMigrated       DomainEventSuspendedDetailType = 1
@@ -1228,10 +1230,10 @@ const (
 	DomainEventSuspendedPostcopyFailed DomainEventSuspendedDetailType = 8
 )
 
-// DomainEventResumedDetailType as declared in libvirt/libvirt-domain.h:2961
+// DomainEventResumedDetailType as declared in libvirt/libvirt-domain.h:2971
 type DomainEventResumedDetailType int32
 
-// DomainEventResumedDetailType enumeration from libvirt/libvirt-domain.h:2961
+// DomainEventResumedDetailType enumeration from libvirt/libvirt-domain.h:2971
 const (
 	DomainEventResumedUnpaused     DomainEventResumedDetailType = iota
 	DomainEventResumedMigrated     DomainEventResumedDetailType = 1
@@ -1239,10 +1241,10 @@ const (
 	DomainEventResumedPostcopy     DomainEventResumedDetailType = 3
 )
 
-// DomainEventStoppedDetailType as declared in libvirt/libvirt-domain.h:2980
+// DomainEventStoppedDetailType as declared in libvirt/libvirt-domain.h:2990
 type DomainEventStoppedDetailType int32
 
-// DomainEventStoppedDetailType enumeration from libvirt/libvirt-domain.h:2980
+// DomainEventStoppedDetailType enumeration from libvirt/libvirt-domain.h:2990
 const (
 	DomainEventStoppedShutdown     DomainEventStoppedDetailType = iota
 	DomainEventStoppedDestroyed    DomainEventStoppedDetailType = 1
@@ -1253,37 +1255,37 @@ const (
 	DomainEventStoppedFromSnapshot DomainEventStoppedDetailType = 6
 )
 
-// DomainEventShutdownDetailType as declared in libvirt/libvirt-domain.h:3003
+// DomainEventShutdownDetailType as declared in libvirt/libvirt-domain.h:3013
 type DomainEventShutdownDetailType int32
 
-// DomainEventShutdownDetailType enumeration from libvirt/libvirt-domain.h:3003
+// DomainEventShutdownDetailType enumeration from libvirt/libvirt-domain.h:3013
 const (
 	DomainEventShutdownFinished DomainEventShutdownDetailType = iota
 	DomainEventShutdownGuest    DomainEventShutdownDetailType = 1
 	DomainEventShutdownHost     DomainEventShutdownDetailType = 2
 )
 
-// DomainEventPMSuspendedDetailType as declared in libvirt/libvirt-domain.h:3017
+// DomainEventPMSuspendedDetailType as declared in libvirt/libvirt-domain.h:3027
 type DomainEventPMSuspendedDetailType int32
 
-// DomainEventPMSuspendedDetailType enumeration from libvirt/libvirt-domain.h:3017
+// DomainEventPMSuspendedDetailType enumeration from libvirt/libvirt-domain.h:3027
 const (
 	DomainEventPmsuspendedMemory DomainEventPMSuspendedDetailType = iota
 	DomainEventPmsuspendedDisk   DomainEventPMSuspendedDetailType = 1
 )
 
-// DomainEventCrashedDetailType as declared in libvirt/libvirt-domain.h:3030
+// DomainEventCrashedDetailType as declared in libvirt/libvirt-domain.h:3040
 type DomainEventCrashedDetailType int32
 
-// DomainEventCrashedDetailType enumeration from libvirt/libvirt-domain.h:3030
+// DomainEventCrashedDetailType enumeration from libvirt/libvirt-domain.h:3040
 const (
 	DomainEventCrashedPanicked DomainEventCrashedDetailType = iota
 )
 
-// DomainJobType as declared in libvirt/libvirt-domain.h:3074
+// DomainJobType as declared in libvirt/libvirt-domain.h:3084
 type DomainJobType int32
 
-// DomainJobType enumeration from libvirt/libvirt-domain.h:3074
+// DomainJobType enumeration from libvirt/libvirt-domain.h:3084
 const (
 	DomainJobNone      DomainJobType = iota
 	DomainJobBounded   DomainJobType = 1
@@ -1293,18 +1295,18 @@ const (
 	DomainJobCancelled DomainJobType = 5
 )
 
-// DomainGetJobStatsFlags as declared in libvirt/libvirt-domain.h:3121
+// DomainGetJobStatsFlags as declared in libvirt/libvirt-domain.h:3131
 type DomainGetJobStatsFlags int32
 
-// DomainGetJobStatsFlags enumeration from libvirt/libvirt-domain.h:3121
+// DomainGetJobStatsFlags enumeration from libvirt/libvirt-domain.h:3131
 const (
 	DomainJobStatsCompleted DomainGetJobStatsFlags = 1
 )
 
-// DomainJobOperation as declared in libvirt/libvirt-domain.h:3146
+// DomainJobOperation as declared in libvirt/libvirt-domain.h:3156
 type DomainJobOperation int32
 
-// DomainJobOperation enumeration from libvirt/libvirt-domain.h:3146
+// DomainJobOperation enumeration from libvirt/libvirt-domain.h:3156
 const (
 	DomainJobOperationStrUnknown        DomainJobOperation = iota
 	DomainJobOperationStrStart          DomainJobOperation = 1
@@ -1317,10 +1319,10 @@ const (
 	DomainJobOperationStrDump           DomainJobOperation = 8
 )
 
-// DomainEventWatchdogAction as declared in libvirt/libvirt-domain.h:3479
+// DomainEventWatchdogAction as declared in libvirt/libvirt-domain.h:3500
 type DomainEventWatchdogAction int32
 
-// DomainEventWatchdogAction enumeration from libvirt/libvirt-domain.h:3479
+// DomainEventWatchdogAction enumeration from libvirt/libvirt-domain.h:3500
 const (
 	DomainEventWatchdogNone      DomainEventWatchdogAction = iota
 	DomainEventWatchdogPause     DomainEventWatchdogAction = 1
@@ -1331,40 +1333,40 @@ const (
 	DomainEventWatchdogInjectnmi DomainEventWatchdogAction = 6
 )
 
-// DomainEventIOErrorAction as declared in libvirt/libvirt-domain.h:3510
+// DomainEventIOErrorAction as declared in libvirt/libvirt-domain.h:3531
 type DomainEventIOErrorAction int32
 
-// DomainEventIOErrorAction enumeration from libvirt/libvirt-domain.h:3510
+// DomainEventIOErrorAction enumeration from libvirt/libvirt-domain.h:3531
 const (
 	DomainEventIoErrorNone   DomainEventIOErrorAction = iota
 	DomainEventIoErrorPause  DomainEventIOErrorAction = 1
 	DomainEventIoErrorReport DomainEventIOErrorAction = 2
 )
 
-// DomainEventGraphicsPhase as declared in libvirt/libvirt-domain.h:3573
+// DomainEventGraphicsPhase as declared in libvirt/libvirt-domain.h:3594
 type DomainEventGraphicsPhase int32
 
-// DomainEventGraphicsPhase enumeration from libvirt/libvirt-domain.h:3573
+// DomainEventGraphicsPhase enumeration from libvirt/libvirt-domain.h:3594
 const (
 	DomainEventGraphicsConnect    DomainEventGraphicsPhase = iota
 	DomainEventGraphicsInitialize DomainEventGraphicsPhase = 1
 	DomainEventGraphicsDisconnect DomainEventGraphicsPhase = 2
 )
 
-// DomainEventGraphicsAddressType as declared in libvirt/libvirt-domain.h:3588
+// DomainEventGraphicsAddressType as declared in libvirt/libvirt-domain.h:3609
 type DomainEventGraphicsAddressType int32
 
-// DomainEventGraphicsAddressType enumeration from libvirt/libvirt-domain.h:3588
+// DomainEventGraphicsAddressType enumeration from libvirt/libvirt-domain.h:3609
 const (
 	DomainEventGraphicsAddressIpv4 DomainEventGraphicsAddressType = iota
 	DomainEventGraphicsAddressIpv6 DomainEventGraphicsAddressType = 1
 	DomainEventGraphicsAddressUnix DomainEventGraphicsAddressType = 2
 )
 
-// ConnectDomainEventBlockJobStatus as declared in libvirt/libvirt-domain.h:3676
+// ConnectDomainEventBlockJobStatus as declared in libvirt/libvirt-domain.h:3697
 type ConnectDomainEventBlockJobStatus int32
 
-// ConnectDomainEventBlockJobStatus enumeration from libvirt/libvirt-domain.h:3676
+// ConnectDomainEventBlockJobStatus enumeration from libvirt/libvirt-domain.h:3697
 const (
 	DomainBlockJobCompleted ConnectDomainEventBlockJobStatus = iota
 	DomainBlockJobFailed    ConnectDomainEventBlockJobStatus = 1
@@ -1372,47 +1374,47 @@ const (
 	DomainBlockJobReady     ConnectDomainEventBlockJobStatus = 3
 )
 
-// ConnectDomainEventDiskChangeReason as declared in libvirt/libvirt-domain.h:3725
+// ConnectDomainEventDiskChangeReason as declared in libvirt/libvirt-domain.h:3747
 type ConnectDomainEventDiskChangeReason int32
 
-// ConnectDomainEventDiskChangeReason enumeration from libvirt/libvirt-domain.h:3725
+// ConnectDomainEventDiskChangeReason enumeration from libvirt/libvirt-domain.h:3747
 const (
 	DomainEventDiskChangeMissingOnStart ConnectDomainEventDiskChangeReason = iota
 	DomainEventDiskDropMissingOnStart   ConnectDomainEventDiskChangeReason = 1
 )
 
-// DomainEventTrayChangeReason as declared in libvirt/libvirt-domain.h:3766
+// DomainEventTrayChangeReason as declared in libvirt/libvirt-domain.h:3788
 type DomainEventTrayChangeReason int32
 
-// DomainEventTrayChangeReason enumeration from libvirt/libvirt-domain.h:3766
+// DomainEventTrayChangeReason enumeration from libvirt/libvirt-domain.h:3788
 const (
 	DomainEventTrayChangeOpen  DomainEventTrayChangeReason = iota
 	DomainEventTrayChangeClose DomainEventTrayChangeReason = 1
 )
 
-// ConnectDomainEventAgentLifecycleState as declared in libvirt/libvirt-domain.h:4281
+// ConnectDomainEventAgentLifecycleState as declared in libvirt/libvirt-domain.h:4303
 type ConnectDomainEventAgentLifecycleState int32
 
-// ConnectDomainEventAgentLifecycleState enumeration from libvirt/libvirt-domain.h:4281
+// ConnectDomainEventAgentLifecycleState enumeration from libvirt/libvirt-domain.h:4303
 const (
 	ConnectDomainEventAgentLifecycleStateConnected    ConnectDomainEventAgentLifecycleState = 1
 	ConnectDomainEventAgentLifecycleStateDisconnected ConnectDomainEventAgentLifecycleState = 2
 )
 
-// ConnectDomainEventAgentLifecycleReason as declared in libvirt/libvirt-domain.h:4291
+// ConnectDomainEventAgentLifecycleReason as declared in libvirt/libvirt-domain.h:4313
 type ConnectDomainEventAgentLifecycleReason int32
 
-// ConnectDomainEventAgentLifecycleReason enumeration from libvirt/libvirt-domain.h:4291
+// ConnectDomainEventAgentLifecycleReason enumeration from libvirt/libvirt-domain.h:4313
 const (
 	ConnectDomainEventAgentLifecycleReasonUnknown       ConnectDomainEventAgentLifecycleReason = iota
 	ConnectDomainEventAgentLifecycleReasonDomainStarted ConnectDomainEventAgentLifecycleReason = 1
 	ConnectDomainEventAgentLifecycleReasonChannel       ConnectDomainEventAgentLifecycleReason = 2
 )
 
-// DomainEventID as declared in libvirt/libvirt-domain.h:4395
+// DomainEventID as declared in libvirt/libvirt-domain.h:4417
 type DomainEventID int32
 
-// DomainEventID enumeration from libvirt/libvirt-domain.h:4395
+// DomainEventID enumeration from libvirt/libvirt-domain.h:4417
 const (
 	DomainEventIDLifecycle           DomainEventID = iota
 	DomainEventIDReboot              DomainEventID = 1
@@ -1441,43 +1443,43 @@ const (
 	DomainEventIDBlockThreshold      DomainEventID = 24
 )
 
-// DomainConsoleFlags as declared in libvirt/libvirt-domain.h:4422
+// DomainConsoleFlags as declared in libvirt/libvirt-domain.h:4444
 type DomainConsoleFlags int32
 
-// DomainConsoleFlags enumeration from libvirt/libvirt-domain.h:4422
+// DomainConsoleFlags enumeration from libvirt/libvirt-domain.h:4444
 const (
 	DomainConsoleForce DomainConsoleFlags = 1
 	DomainConsoleSafe  DomainConsoleFlags = 2
 )
 
-// DomainChannelFlags as declared in libvirt/libvirt-domain.h:4438
+// DomainChannelFlags as declared in libvirt/libvirt-domain.h:4460
 type DomainChannelFlags int32
 
-// DomainChannelFlags enumeration from libvirt/libvirt-domain.h:4438
+// DomainChannelFlags enumeration from libvirt/libvirt-domain.h:4460
 const (
 	DomainChannelForce DomainChannelFlags = 1
 )
 
-// DomainOpenGraphicsFlags as declared in libvirt/libvirt-domain.h:4447
+// DomainOpenGraphicsFlags as declared in libvirt/libvirt-domain.h:4469
 type DomainOpenGraphicsFlags int32
 
-// DomainOpenGraphicsFlags enumeration from libvirt/libvirt-domain.h:4447
+// DomainOpenGraphicsFlags enumeration from libvirt/libvirt-domain.h:4469
 const (
 	DomainOpenGraphicsSkipauth DomainOpenGraphicsFlags = 1
 )
 
-// DomainSetTimeFlags as declared in libvirt/libvirt-domain.h:4504
+// DomainSetTimeFlags as declared in libvirt/libvirt-domain.h:4526
 type DomainSetTimeFlags int32
 
-// DomainSetTimeFlags enumeration from libvirt/libvirt-domain.h:4504
+// DomainSetTimeFlags enumeration from libvirt/libvirt-domain.h:4526
 const (
 	DomainTimeSync DomainSetTimeFlags = 1
 )
 
-// SchedParameterType as declared in libvirt/libvirt-domain.h:4525
+// SchedParameterType as declared in libvirt/libvirt-domain.h:4547
 type SchedParameterType int32
 
-// SchedParameterType enumeration from libvirt/libvirt-domain.h:4525
+// SchedParameterType enumeration from libvirt/libvirt-domain.h:4547
 const (
 	DomainSchedFieldInt     SchedParameterType = 1
 	DomainSchedFieldUint    SchedParameterType = 2
@@ -1487,10 +1489,10 @@ const (
 	DomainSchedFieldBoolean SchedParameterType = 6
 )
 
-// BlkioParameterType as declared in libvirt/libvirt-domain.h:4569
+// BlkioParameterType as declared in libvirt/libvirt-domain.h:4591
 type BlkioParameterType int32
 
-// BlkioParameterType enumeration from libvirt/libvirt-domain.h:4569
+// BlkioParameterType enumeration from libvirt/libvirt-domain.h:4591
 const (
 	DomainBlkioParamInt     BlkioParameterType = 1
 	DomainBlkioParamUint    BlkioParameterType = 2
@@ -1500,10 +1502,10 @@ const (
 	DomainBlkioParamBoolean BlkioParameterType = 6
 )
 
-// MemoryParameterType as declared in libvirt/libvirt-domain.h:4613
+// MemoryParameterType as declared in libvirt/libvirt-domain.h:4635
 type MemoryParameterType int32
 
-// MemoryParameterType enumeration from libvirt/libvirt-domain.h:4613
+// MemoryParameterType enumeration from libvirt/libvirt-domain.h:4635
 const (
 	DomainMemoryParamInt     MemoryParameterType = 1
 	DomainMemoryParamUint    MemoryParameterType = 2
@@ -1513,21 +1515,44 @@ const (
 	DomainMemoryParamBoolean MemoryParameterType = 6
 )
 
-// DomainInterfaceAddressesSource as declared in libvirt/libvirt-domain.h:4650
+// DomainInterfaceAddressesSource as declared in libvirt/libvirt-domain.h:4672
 type DomainInterfaceAddressesSource int32
 
-// DomainInterfaceAddressesSource enumeration from libvirt/libvirt-domain.h:4650
+// DomainInterfaceAddressesSource enumeration from libvirt/libvirt-domain.h:4672
 const (
 	DomainInterfaceAddressesSrcLease DomainInterfaceAddressesSource = iota
 	DomainInterfaceAddressesSrcAgent DomainInterfaceAddressesSource = 1
 )
 
-// DomainSetUserPasswordFlags as declared in libvirt/libvirt-domain.h:4678
+// DomainSetUserPasswordFlags as declared in libvirt/libvirt-domain.h:4700
 type DomainSetUserPasswordFlags int32
 
-// DomainSetUserPasswordFlags enumeration from libvirt/libvirt-domain.h:4678
+// DomainSetUserPasswordFlags enumeration from libvirt/libvirt-domain.h:4700
 const (
 	DomainPasswordEncrypted DomainSetUserPasswordFlags = 1
+)
+
+// DomainLifecycle as declared in libvirt/libvirt-domain.h:4739
+type DomainLifecycle int32
+
+// DomainLifecycle enumeration from libvirt/libvirt-domain.h:4739
+const (
+	DomainLifecyclePoweroff DomainLifecycle = iota
+	DomainLifecycleReboot   DomainLifecycle = 1
+	DomainLifecycleCrash    DomainLifecycle = 2
+)
+
+// DomainLifecycleAction as declared in libvirt/libvirt-domain.h:4752
+type DomainLifecycleAction int32
+
+// DomainLifecycleAction enumeration from libvirt/libvirt-domain.h:4752
+const (
+	DomainLifecycleActionDestroy         DomainLifecycleAction = iota
+	DomainLifecycleActionRestart         DomainLifecycleAction = 1
+	DomainLifecycleActionRestartRename   DomainLifecycleAction = 2
+	DomainLifecycleActionPreserve        DomainLifecycleAction = 3
+	DomainLifecycleActionCoredumpDestroy DomainLifecycleAction = 4
+	DomainLifecycleActionCoredumpRestart DomainLifecycleAction = 5
 )
 
 // DomainSnapshotCreateFlags as declared in libvirt/libvirt-domain-snapshot.h:73
@@ -1956,15 +1981,17 @@ const (
 	StoragePoolEventIDRefresh   StoragePoolEventID = 1
 )
 
-// StoragePoolEventLifecycleType as declared in libvirt/libvirt-storage.h:472
+// StoragePoolEventLifecycleType as declared in libvirt/libvirt-storage.h:474
 type StoragePoolEventLifecycleType int32
 
-// StoragePoolEventLifecycleType enumeration from libvirt/libvirt-storage.h:472
+// StoragePoolEventLifecycleType enumeration from libvirt/libvirt-storage.h:474
 const (
 	StoragePoolEventDefined   StoragePoolEventLifecycleType = iota
 	StoragePoolEventUndefined StoragePoolEventLifecycleType = 1
 	StoragePoolEventStarted   StoragePoolEventLifecycleType = 2
 	StoragePoolEventStopped   StoragePoolEventLifecycleType = 3
+	StoragePoolEventCreated   StoragePoolEventLifecycleType = 4
+	StoragePoolEventDeleted   StoragePoolEventLifecycleType = 5
 )
 
 // StreamFlags as declared in libvirt/libvirt-stream.h:34
@@ -1983,10 +2010,10 @@ const (
 	StreamRecvStopAtHole StreamRecvFlagsValues = 1
 )
 
-// StreamEventType as declared in libvirt/libvirt-stream.h:223
+// StreamEventType as declared in libvirt/libvirt-stream.h:238
 type StreamEventType int32
 
-// StreamEventType enumeration from libvirt/libvirt-stream.h:223
+// StreamEventType enumeration from libvirt/libvirt-stream.h:238
 const (
 	StreamEventReadable StreamEventType = 1
 	StreamEventWritable StreamEventType = 2

--- a/scripts/gen-consts.sh
+++ b/scripts/gen-consts.sh
@@ -19,6 +19,7 @@ if ! which c-for-go > /dev/null; then
     # __GNUC_PREREQ macro. Checkout an older version to avoid this.
     pushd $GOPATH/src/github.com/xlab/c-for-go
     git checkout a831fa1954c29f84f7bccab225c3c620d0e7f132
+    go install ./...
     popd
 fi
 

--- a/scripts/gen-consts.sh
+++ b/scripts/gen-consts.sh
@@ -15,6 +15,11 @@ if ! which c-for-go > /dev/null; then
         echo "failed to install c-for-go. Please install it manually from https://github.com/xlab/c-for-go"
         exit 1
     fi
+    # HEAD is broken for us because of a failed attempt to redefine the
+    # __GNUC_PREREQ macro. Checkout an older version to avoid this.
+    pushd $GOPATH/src/github.com/xlab/c-for-go
+    git checkout a831fa1954c29f84f7bccab225c3c620d0e7f132
+    popd
 fi
 
 # Make sure goyacc is installed (needed for the lvgen/ generator)


### PR DESCRIPTION
- Our travis build had become broken because of a bug in the latest version of c-for-go. I've submitted a patch upstream to fix that, but in the meantime this adds some code to checkout an older version for our build.
- Regenerate the generated code using the libvirt-4.0.0 code.