### PR TITLE
Return []byte from encode, use it instead of bytes.Buffer

### DIFF
--- a/internal/lvgen/procedures.tmpl
+++ b/internal/lvgen/procedures.tmpl
@@ -129,7 +129,7 @@ func decodeTypedParams(dec *xdr.Decoder) ([]TypedParam, error) {
 {{range .Procs}}
 // {{.Name}} is the go wrapper for {{.LVName}}.
 func (l *Libvirt) {{.Name}}({{range $ix, $arg := .Args}}{{if $ix}}, {{end}}{{.Name}} {{.Type}}{{end}}) ({{range .Ret}}r{{.Name}} {{.Type}}, {{end}}err error) {
-	var buf bytes.Buffer
+	var buf []byte
 {{if .ArgsStruct}}
 	args := {{.ArgsStruct}} {
 {{range .Args}}		{{.Name}}: {{.Name}},
@@ -141,7 +141,7 @@ func (l *Libvirt) {{.Name}}({{range $ix, $arg := .Args}}{{if $ix}}, {{end}}{{.Na
 	}
 {{end}}
 {{if .RetStruct}}	var r response{{end}}
-	{{if .RetStruct}}r{{else}}_{{end}}, err = l.request({{.Num}}, constants.Program, &buf)
+	{{if .RetStruct}}r{{else}}_{{end}}, err = l.request({{.Num}}, constants.Program, buf)
 	if err != nil {
 		return
 	}

--- a/libvirt.gen.go
+++ b/libvirt.gen.go
@@ -3939,7 +3939,7 @@ func decodeTypedParams(dec *xdr.Decoder) ([]TypedParam, error) {
 
 // ConnectOpen is the go wrapper for REMOTE_PROC_CONNECT_OPEN.
 func (l *Libvirt) ConnectOpen(Name OptString, Flags ConnectFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectOpenArgs {
 		Name: Name,
@@ -3952,7 +3952,7 @@ func (l *Libvirt) ConnectOpen(Name OptString, Flags ConnectFlags) (err error) {
 	}
 
 
-	_, err = l.request(1, constants.Program, &buf)
+	_, err = l.request(1, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -3962,10 +3962,10 @@ func (l *Libvirt) ConnectOpen(Name OptString, Flags ConnectFlags) (err error) {
 
 // ConnectClose is the go wrapper for REMOTE_PROC_CONNECT_CLOSE.
 func (l *Libvirt) ConnectClose() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(2, constants.Program, &buf)
+	_, err = l.request(2, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -3975,10 +3975,10 @@ func (l *Libvirt) ConnectClose() (err error) {
 
 // ConnectGetType is the go wrapper for REMOTE_PROC_CONNECT_GET_TYPE.
 func (l *Libvirt) ConnectGetType() (rType string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(3, constants.Program, &buf)
+	r, err = l.request(3, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -3997,10 +3997,10 @@ func (l *Libvirt) ConnectGetType() (rType string, err error) {
 
 // ConnectGetVersion is the go wrapper for REMOTE_PROC_CONNECT_GET_VERSION.
 func (l *Libvirt) ConnectGetVersion() (rHvVer uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(4, constants.Program, &buf)
+	r, err = l.request(4, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4019,7 +4019,7 @@ func (l *Libvirt) ConnectGetVersion() (rHvVer uint64, err error) {
 
 // ConnectGetMaxVcpus is the go wrapper for REMOTE_PROC_CONNECT_GET_MAX_VCPUS.
 func (l *Libvirt) ConnectGetMaxVcpus(Type OptString) (rMaxVcpus int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectGetMaxVcpusArgs {
 		Type: Type,
@@ -4031,7 +4031,7 @@ func (l *Libvirt) ConnectGetMaxVcpus(Type OptString) (rMaxVcpus int32, err error
 	}
 
 	var r response
-	r, err = l.request(5, constants.Program, &buf)
+	r, err = l.request(5, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4050,10 +4050,10 @@ func (l *Libvirt) ConnectGetMaxVcpus(Type OptString) (rMaxVcpus int32, err error
 
 // NodeGetInfo is the go wrapper for REMOTE_PROC_NODE_GET_INFO.
 func (l *Libvirt) NodeGetInfo() (rModel [32]int8, rMemory uint64, rCpus int32, rMhz int32, rNodes int32, rSockets int32, rCores int32, rThreads int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(6, constants.Program, &buf)
+	r, err = l.request(6, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4107,10 +4107,10 @@ func (l *Libvirt) NodeGetInfo() (rModel [32]int8, rMemory uint64, rCpus int32, r
 
 // ConnectGetCapabilities is the go wrapper for REMOTE_PROC_CONNECT_GET_CAPABILITIES.
 func (l *Libvirt) ConnectGetCapabilities() (rCapabilities string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(7, constants.Program, &buf)
+	r, err = l.request(7, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4129,7 +4129,7 @@ func (l *Libvirt) ConnectGetCapabilities() (rCapabilities string, err error) {
 
 // DomainAttachDevice is the go wrapper for REMOTE_PROC_DOMAIN_ATTACH_DEVICE.
 func (l *Libvirt) DomainAttachDevice(Dom Domain, XML string) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainAttachDeviceArgs {
 		Dom: Dom,
@@ -4142,7 +4142,7 @@ func (l *Libvirt) DomainAttachDevice(Dom Domain, XML string) (err error) {
 	}
 
 
-	_, err = l.request(8, constants.Program, &buf)
+	_, err = l.request(8, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4152,7 +4152,7 @@ func (l *Libvirt) DomainAttachDevice(Dom Domain, XML string) (err error) {
 
 // DomainCreate is the go wrapper for REMOTE_PROC_DOMAIN_CREATE.
 func (l *Libvirt) DomainCreate(Dom Domain) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainCreateArgs {
 		Dom: Dom,
@@ -4164,7 +4164,7 @@ func (l *Libvirt) DomainCreate(Dom Domain) (err error) {
 	}
 
 
-	_, err = l.request(9, constants.Program, &buf)
+	_, err = l.request(9, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4174,7 +4174,7 @@ func (l *Libvirt) DomainCreate(Dom Domain) (err error) {
 
 // DomainCreateXML is the go wrapper for REMOTE_PROC_DOMAIN_CREATE_XML.
 func (l *Libvirt) DomainCreateXML(XMLDesc string, Flags DomainCreateFlags) (rDom Domain, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainCreateXMLArgs {
 		XMLDesc: XMLDesc,
@@ -4187,7 +4187,7 @@ func (l *Libvirt) DomainCreateXML(XMLDesc string, Flags DomainCreateFlags) (rDom
 	}
 
 	var r response
-	r, err = l.request(10, constants.Program, &buf)
+	r, err = l.request(10, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4206,7 +4206,7 @@ func (l *Libvirt) DomainCreateXML(XMLDesc string, Flags DomainCreateFlags) (rDom
 
 // DomainDefineXML is the go wrapper for REMOTE_PROC_DOMAIN_DEFINE_XML.
 func (l *Libvirt) DomainDefineXML(XML string) (rDom Domain, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainDefineXMLArgs {
 		XML: XML,
@@ -4218,7 +4218,7 @@ func (l *Libvirt) DomainDefineXML(XML string) (rDom Domain, err error) {
 	}
 
 	var r response
-	r, err = l.request(11, constants.Program, &buf)
+	r, err = l.request(11, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4237,7 +4237,7 @@ func (l *Libvirt) DomainDefineXML(XML string) (rDom Domain, err error) {
 
 // DomainDestroy is the go wrapper for REMOTE_PROC_DOMAIN_DESTROY.
 func (l *Libvirt) DomainDestroy(Dom Domain) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainDestroyArgs {
 		Dom: Dom,
@@ -4249,7 +4249,7 @@ func (l *Libvirt) DomainDestroy(Dom Domain) (err error) {
 	}
 
 
-	_, err = l.request(12, constants.Program, &buf)
+	_, err = l.request(12, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4259,7 +4259,7 @@ func (l *Libvirt) DomainDestroy(Dom Domain) (err error) {
 
 // DomainDetachDevice is the go wrapper for REMOTE_PROC_DOMAIN_DETACH_DEVICE.
 func (l *Libvirt) DomainDetachDevice(Dom Domain, XML string) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainDetachDeviceArgs {
 		Dom: Dom,
@@ -4272,7 +4272,7 @@ func (l *Libvirt) DomainDetachDevice(Dom Domain, XML string) (err error) {
 	}
 
 
-	_, err = l.request(13, constants.Program, &buf)
+	_, err = l.request(13, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4282,7 +4282,7 @@ func (l *Libvirt) DomainDetachDevice(Dom Domain, XML string) (err error) {
 
 // DomainGetXMLDesc is the go wrapper for REMOTE_PROC_DOMAIN_GET_XML_DESC.
 func (l *Libvirt) DomainGetXMLDesc(Dom Domain, Flags DomainXMLFlags) (rXML string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetXMLDescArgs {
 		Dom: Dom,
@@ -4295,7 +4295,7 @@ func (l *Libvirt) DomainGetXMLDesc(Dom Domain, Flags DomainXMLFlags) (rXML strin
 	}
 
 	var r response
-	r, err = l.request(14, constants.Program, &buf)
+	r, err = l.request(14, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4314,7 +4314,7 @@ func (l *Libvirt) DomainGetXMLDesc(Dom Domain, Flags DomainXMLFlags) (rXML strin
 
 // DomainGetAutostart is the go wrapper for REMOTE_PROC_DOMAIN_GET_AUTOSTART.
 func (l *Libvirt) DomainGetAutostart(Dom Domain) (rAutostart int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetAutostartArgs {
 		Dom: Dom,
@@ -4326,7 +4326,7 @@ func (l *Libvirt) DomainGetAutostart(Dom Domain) (rAutostart int32, err error) {
 	}
 
 	var r response
-	r, err = l.request(15, constants.Program, &buf)
+	r, err = l.request(15, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4345,7 +4345,7 @@ func (l *Libvirt) DomainGetAutostart(Dom Domain) (rAutostart int32, err error) {
 
 // DomainGetInfo is the go wrapper for REMOTE_PROC_DOMAIN_GET_INFO.
 func (l *Libvirt) DomainGetInfo(Dom Domain) (rState uint8, rMaxMem uint64, rMemory uint64, rNrVirtCPU uint16, rCPUTime uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetInfoArgs {
 		Dom: Dom,
@@ -4357,7 +4357,7 @@ func (l *Libvirt) DomainGetInfo(Dom Domain) (rState uint8, rMaxMem uint64, rMemo
 	}
 
 	var r response
-	r, err = l.request(16, constants.Program, &buf)
+	r, err = l.request(16, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4396,7 +4396,7 @@ func (l *Libvirt) DomainGetInfo(Dom Domain) (rState uint8, rMaxMem uint64, rMemo
 
 // DomainGetMaxMemory is the go wrapper for REMOTE_PROC_DOMAIN_GET_MAX_MEMORY.
 func (l *Libvirt) DomainGetMaxMemory(Dom Domain) (rMemory uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetMaxMemoryArgs {
 		Dom: Dom,
@@ -4408,7 +4408,7 @@ func (l *Libvirt) DomainGetMaxMemory(Dom Domain) (rMemory uint64, err error) {
 	}
 
 	var r response
-	r, err = l.request(17, constants.Program, &buf)
+	r, err = l.request(17, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4427,7 +4427,7 @@ func (l *Libvirt) DomainGetMaxMemory(Dom Domain) (rMemory uint64, err error) {
 
 // DomainGetMaxVcpus is the go wrapper for REMOTE_PROC_DOMAIN_GET_MAX_VCPUS.
 func (l *Libvirt) DomainGetMaxVcpus(Dom Domain) (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetMaxVcpusArgs {
 		Dom: Dom,
@@ -4439,7 +4439,7 @@ func (l *Libvirt) DomainGetMaxVcpus(Dom Domain) (rNum int32, err error) {
 	}
 
 	var r response
-	r, err = l.request(18, constants.Program, &buf)
+	r, err = l.request(18, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4458,7 +4458,7 @@ func (l *Libvirt) DomainGetMaxVcpus(Dom Domain) (rNum int32, err error) {
 
 // DomainGetOsType is the go wrapper for REMOTE_PROC_DOMAIN_GET_OS_TYPE.
 func (l *Libvirt) DomainGetOsType(Dom Domain) (rType string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetOsTypeArgs {
 		Dom: Dom,
@@ -4470,7 +4470,7 @@ func (l *Libvirt) DomainGetOsType(Dom Domain) (rType string, err error) {
 	}
 
 	var r response
-	r, err = l.request(19, constants.Program, &buf)
+	r, err = l.request(19, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4489,7 +4489,7 @@ func (l *Libvirt) DomainGetOsType(Dom Domain) (rType string, err error) {
 
 // DomainGetVcpus is the go wrapper for REMOTE_PROC_DOMAIN_GET_VCPUS.
 func (l *Libvirt) DomainGetVcpus(Dom Domain, Maxinfo int32, Maplen int32) (rInfo []VcpuInfo, rCpumaps []byte, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetVcpusArgs {
 		Dom: Dom,
@@ -4503,7 +4503,7 @@ func (l *Libvirt) DomainGetVcpus(Dom Domain, Maxinfo int32, Maplen int32) (rInfo
 	}
 
 	var r response
-	r, err = l.request(20, constants.Program, &buf)
+	r, err = l.request(20, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4527,7 +4527,7 @@ func (l *Libvirt) DomainGetVcpus(Dom Domain, Maxinfo int32, Maplen int32) (rInfo
 
 // ConnectListDefinedDomains is the go wrapper for REMOTE_PROC_CONNECT_LIST_DEFINED_DOMAINS.
 func (l *Libvirt) ConnectListDefinedDomains(Maxnames int32) (rNames []string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListDefinedDomainsArgs {
 		Maxnames: Maxnames,
@@ -4539,7 +4539,7 @@ func (l *Libvirt) ConnectListDefinedDomains(Maxnames int32) (rNames []string, er
 	}
 
 	var r response
-	r, err = l.request(21, constants.Program, &buf)
+	r, err = l.request(21, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4558,7 +4558,7 @@ func (l *Libvirt) ConnectListDefinedDomains(Maxnames int32) (rNames []string, er
 
 // DomainLookupByID is the go wrapper for REMOTE_PROC_DOMAIN_LOOKUP_BY_ID.
 func (l *Libvirt) DomainLookupByID(ID int32) (rDom Domain, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainLookupByIDArgs {
 		ID: ID,
@@ -4570,7 +4570,7 @@ func (l *Libvirt) DomainLookupByID(ID int32) (rDom Domain, err error) {
 	}
 
 	var r response
-	r, err = l.request(22, constants.Program, &buf)
+	r, err = l.request(22, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4589,7 +4589,7 @@ func (l *Libvirt) DomainLookupByID(ID int32) (rDom Domain, err error) {
 
 // DomainLookupByName is the go wrapper for REMOTE_PROC_DOMAIN_LOOKUP_BY_NAME.
 func (l *Libvirt) DomainLookupByName(Name string) (rDom Domain, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainLookupByNameArgs {
 		Name: Name,
@@ -4601,7 +4601,7 @@ func (l *Libvirt) DomainLookupByName(Name string) (rDom Domain, err error) {
 	}
 
 	var r response
-	r, err = l.request(23, constants.Program, &buf)
+	r, err = l.request(23, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4620,7 +4620,7 @@ func (l *Libvirt) DomainLookupByName(Name string) (rDom Domain, err error) {
 
 // DomainLookupByUUID is the go wrapper for REMOTE_PROC_DOMAIN_LOOKUP_BY_UUID.
 func (l *Libvirt) DomainLookupByUUID(UUID UUID) (rDom Domain, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainLookupByUUIDArgs {
 		UUID: UUID,
@@ -4632,7 +4632,7 @@ func (l *Libvirt) DomainLookupByUUID(UUID UUID) (rDom Domain, err error) {
 	}
 
 	var r response
-	r, err = l.request(24, constants.Program, &buf)
+	r, err = l.request(24, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4651,10 +4651,10 @@ func (l *Libvirt) DomainLookupByUUID(UUID UUID) (rDom Domain, err error) {
 
 // ConnectNumOfDefinedDomains is the go wrapper for REMOTE_PROC_CONNECT_NUM_OF_DEFINED_DOMAINS.
 func (l *Libvirt) ConnectNumOfDefinedDomains() (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(25, constants.Program, &buf)
+	r, err = l.request(25, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4673,7 +4673,7 @@ func (l *Libvirt) ConnectNumOfDefinedDomains() (rNum int32, err error) {
 
 // DomainPinVcpu is the go wrapper for REMOTE_PROC_DOMAIN_PIN_VCPU.
 func (l *Libvirt) DomainPinVcpu(Dom Domain, Vcpu uint32, Cpumap []byte) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainPinVcpuArgs {
 		Dom: Dom,
@@ -4687,7 +4687,7 @@ func (l *Libvirt) DomainPinVcpu(Dom Domain, Vcpu uint32, Cpumap []byte) (err err
 	}
 
 
-	_, err = l.request(26, constants.Program, &buf)
+	_, err = l.request(26, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4697,7 +4697,7 @@ func (l *Libvirt) DomainPinVcpu(Dom Domain, Vcpu uint32, Cpumap []byte) (err err
 
 // DomainReboot is the go wrapper for REMOTE_PROC_DOMAIN_REBOOT.
 func (l *Libvirt) DomainReboot(Dom Domain, Flags DomainRebootFlagValues) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainRebootArgs {
 		Dom: Dom,
@@ -4710,7 +4710,7 @@ func (l *Libvirt) DomainReboot(Dom Domain, Flags DomainRebootFlagValues) (err er
 	}
 
 
-	_, err = l.request(27, constants.Program, &buf)
+	_, err = l.request(27, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4720,7 +4720,7 @@ func (l *Libvirt) DomainReboot(Dom Domain, Flags DomainRebootFlagValues) (err er
 
 // DomainResume is the go wrapper for REMOTE_PROC_DOMAIN_RESUME.
 func (l *Libvirt) DomainResume(Dom Domain) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainResumeArgs {
 		Dom: Dom,
@@ -4732,7 +4732,7 @@ func (l *Libvirt) DomainResume(Dom Domain) (err error) {
 	}
 
 
-	_, err = l.request(28, constants.Program, &buf)
+	_, err = l.request(28, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4742,7 +4742,7 @@ func (l *Libvirt) DomainResume(Dom Domain) (err error) {
 
 // DomainSetAutostart is the go wrapper for REMOTE_PROC_DOMAIN_SET_AUTOSTART.
 func (l *Libvirt) DomainSetAutostart(Dom Domain, Autostart int32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetAutostartArgs {
 		Dom: Dom,
@@ -4755,7 +4755,7 @@ func (l *Libvirt) DomainSetAutostart(Dom Domain, Autostart int32) (err error) {
 	}
 
 
-	_, err = l.request(29, constants.Program, &buf)
+	_, err = l.request(29, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4765,7 +4765,7 @@ func (l *Libvirt) DomainSetAutostart(Dom Domain, Autostart int32) (err error) {
 
 // DomainSetMaxMemory is the go wrapper for REMOTE_PROC_DOMAIN_SET_MAX_MEMORY.
 func (l *Libvirt) DomainSetMaxMemory(Dom Domain, Memory uint64) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetMaxMemoryArgs {
 		Dom: Dom,
@@ -4778,7 +4778,7 @@ func (l *Libvirt) DomainSetMaxMemory(Dom Domain, Memory uint64) (err error) {
 	}
 
 
-	_, err = l.request(30, constants.Program, &buf)
+	_, err = l.request(30, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4788,7 +4788,7 @@ func (l *Libvirt) DomainSetMaxMemory(Dom Domain, Memory uint64) (err error) {
 
 // DomainSetMemory is the go wrapper for REMOTE_PROC_DOMAIN_SET_MEMORY.
 func (l *Libvirt) DomainSetMemory(Dom Domain, Memory uint64) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetMemoryArgs {
 		Dom: Dom,
@@ -4801,7 +4801,7 @@ func (l *Libvirt) DomainSetMemory(Dom Domain, Memory uint64) (err error) {
 	}
 
 
-	_, err = l.request(31, constants.Program, &buf)
+	_, err = l.request(31, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4811,7 +4811,7 @@ func (l *Libvirt) DomainSetMemory(Dom Domain, Memory uint64) (err error) {
 
 // DomainSetVcpus is the go wrapper for REMOTE_PROC_DOMAIN_SET_VCPUS.
 func (l *Libvirt) DomainSetVcpus(Dom Domain, Nvcpus uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetVcpusArgs {
 		Dom: Dom,
@@ -4824,7 +4824,7 @@ func (l *Libvirt) DomainSetVcpus(Dom Domain, Nvcpus uint32) (err error) {
 	}
 
 
-	_, err = l.request(32, constants.Program, &buf)
+	_, err = l.request(32, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4834,7 +4834,7 @@ func (l *Libvirt) DomainSetVcpus(Dom Domain, Nvcpus uint32) (err error) {
 
 // DomainShutdown is the go wrapper for REMOTE_PROC_DOMAIN_SHUTDOWN.
 func (l *Libvirt) DomainShutdown(Dom Domain) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainShutdownArgs {
 		Dom: Dom,
@@ -4846,7 +4846,7 @@ func (l *Libvirt) DomainShutdown(Dom Domain) (err error) {
 	}
 
 
-	_, err = l.request(33, constants.Program, &buf)
+	_, err = l.request(33, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4856,7 +4856,7 @@ func (l *Libvirt) DomainShutdown(Dom Domain) (err error) {
 
 // DomainSuspend is the go wrapper for REMOTE_PROC_DOMAIN_SUSPEND.
 func (l *Libvirt) DomainSuspend(Dom Domain) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSuspendArgs {
 		Dom: Dom,
@@ -4868,7 +4868,7 @@ func (l *Libvirt) DomainSuspend(Dom Domain) (err error) {
 	}
 
 
-	_, err = l.request(34, constants.Program, &buf)
+	_, err = l.request(34, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4878,7 +4878,7 @@ func (l *Libvirt) DomainSuspend(Dom Domain) (err error) {
 
 // DomainUndefine is the go wrapper for REMOTE_PROC_DOMAIN_UNDEFINE.
 func (l *Libvirt) DomainUndefine(Dom Domain) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainUndefineArgs {
 		Dom: Dom,
@@ -4890,7 +4890,7 @@ func (l *Libvirt) DomainUndefine(Dom Domain) (err error) {
 	}
 
 
-	_, err = l.request(35, constants.Program, &buf)
+	_, err = l.request(35, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4900,7 +4900,7 @@ func (l *Libvirt) DomainUndefine(Dom Domain) (err error) {
 
 // ConnectListDefinedNetworks is the go wrapper for REMOTE_PROC_CONNECT_LIST_DEFINED_NETWORKS.
 func (l *Libvirt) ConnectListDefinedNetworks(Maxnames int32) (rNames []string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListDefinedNetworksArgs {
 		Maxnames: Maxnames,
@@ -4912,7 +4912,7 @@ func (l *Libvirt) ConnectListDefinedNetworks(Maxnames int32) (rNames []string, e
 	}
 
 	var r response
-	r, err = l.request(36, constants.Program, &buf)
+	r, err = l.request(36, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4931,7 +4931,7 @@ func (l *Libvirt) ConnectListDefinedNetworks(Maxnames int32) (rNames []string, e
 
 // ConnectListDomains is the go wrapper for REMOTE_PROC_CONNECT_LIST_DOMAINS.
 func (l *Libvirt) ConnectListDomains(Maxids int32) (rIds []int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListDomainsArgs {
 		Maxids: Maxids,
@@ -4943,7 +4943,7 @@ func (l *Libvirt) ConnectListDomains(Maxids int32) (rIds []int32, err error) {
 	}
 
 	var r response
-	r, err = l.request(37, constants.Program, &buf)
+	r, err = l.request(37, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4962,7 +4962,7 @@ func (l *Libvirt) ConnectListDomains(Maxids int32) (rIds []int32, err error) {
 
 // ConnectListNetworks is the go wrapper for REMOTE_PROC_CONNECT_LIST_NETWORKS.
 func (l *Libvirt) ConnectListNetworks(Maxnames int32) (rNames []string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListNetworksArgs {
 		Maxnames: Maxnames,
@@ -4974,7 +4974,7 @@ func (l *Libvirt) ConnectListNetworks(Maxnames int32) (rNames []string, err erro
 	}
 
 	var r response
-	r, err = l.request(38, constants.Program, &buf)
+	r, err = l.request(38, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -4993,7 +4993,7 @@ func (l *Libvirt) ConnectListNetworks(Maxnames int32) (rNames []string, err erro
 
 // NetworkCreate is the go wrapper for REMOTE_PROC_NETWORK_CREATE.
 func (l *Libvirt) NetworkCreate(Net Network) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NetworkCreateArgs {
 		Net: Net,
@@ -5005,7 +5005,7 @@ func (l *Libvirt) NetworkCreate(Net Network) (err error) {
 	}
 
 
-	_, err = l.request(39, constants.Program, &buf)
+	_, err = l.request(39, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5015,7 +5015,7 @@ func (l *Libvirt) NetworkCreate(Net Network) (err error) {
 
 // NetworkCreateXML is the go wrapper for REMOTE_PROC_NETWORK_CREATE_XML.
 func (l *Libvirt) NetworkCreateXML(XML string) (rNet Network, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NetworkCreateXMLArgs {
 		XML: XML,
@@ -5027,7 +5027,7 @@ func (l *Libvirt) NetworkCreateXML(XML string) (rNet Network, err error) {
 	}
 
 	var r response
-	r, err = l.request(40, constants.Program, &buf)
+	r, err = l.request(40, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5046,7 +5046,7 @@ func (l *Libvirt) NetworkCreateXML(XML string) (rNet Network, err error) {
 
 // NetworkDefineXML is the go wrapper for REMOTE_PROC_NETWORK_DEFINE_XML.
 func (l *Libvirt) NetworkDefineXML(XML string) (rNet Network, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NetworkDefineXMLArgs {
 		XML: XML,
@@ -5058,7 +5058,7 @@ func (l *Libvirt) NetworkDefineXML(XML string) (rNet Network, err error) {
 	}
 
 	var r response
-	r, err = l.request(41, constants.Program, &buf)
+	r, err = l.request(41, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5077,7 +5077,7 @@ func (l *Libvirt) NetworkDefineXML(XML string) (rNet Network, err error) {
 
 // NetworkDestroy is the go wrapper for REMOTE_PROC_NETWORK_DESTROY.
 func (l *Libvirt) NetworkDestroy(Net Network) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NetworkDestroyArgs {
 		Net: Net,
@@ -5089,7 +5089,7 @@ func (l *Libvirt) NetworkDestroy(Net Network) (err error) {
 	}
 
 
-	_, err = l.request(42, constants.Program, &buf)
+	_, err = l.request(42, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5099,7 +5099,7 @@ func (l *Libvirt) NetworkDestroy(Net Network) (err error) {
 
 // NetworkGetXMLDesc is the go wrapper for REMOTE_PROC_NETWORK_GET_XML_DESC.
 func (l *Libvirt) NetworkGetXMLDesc(Net Network, Flags uint32) (rXML string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NetworkGetXMLDescArgs {
 		Net: Net,
@@ -5112,7 +5112,7 @@ func (l *Libvirt) NetworkGetXMLDesc(Net Network, Flags uint32) (rXML string, err
 	}
 
 	var r response
-	r, err = l.request(43, constants.Program, &buf)
+	r, err = l.request(43, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5131,7 +5131,7 @@ func (l *Libvirt) NetworkGetXMLDesc(Net Network, Flags uint32) (rXML string, err
 
 // NetworkGetAutostart is the go wrapper for REMOTE_PROC_NETWORK_GET_AUTOSTART.
 func (l *Libvirt) NetworkGetAutostart(Net Network) (rAutostart int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NetworkGetAutostartArgs {
 		Net: Net,
@@ -5143,7 +5143,7 @@ func (l *Libvirt) NetworkGetAutostart(Net Network) (rAutostart int32, err error)
 	}
 
 	var r response
-	r, err = l.request(44, constants.Program, &buf)
+	r, err = l.request(44, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5162,7 +5162,7 @@ func (l *Libvirt) NetworkGetAutostart(Net Network) (rAutostart int32, err error)
 
 // NetworkGetBridgeName is the go wrapper for REMOTE_PROC_NETWORK_GET_BRIDGE_NAME.
 func (l *Libvirt) NetworkGetBridgeName(Net Network) (rName string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NetworkGetBridgeNameArgs {
 		Net: Net,
@@ -5174,7 +5174,7 @@ func (l *Libvirt) NetworkGetBridgeName(Net Network) (rName string, err error) {
 	}
 
 	var r response
-	r, err = l.request(45, constants.Program, &buf)
+	r, err = l.request(45, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5193,7 +5193,7 @@ func (l *Libvirt) NetworkGetBridgeName(Net Network) (rName string, err error) {
 
 // NetworkLookupByName is the go wrapper for REMOTE_PROC_NETWORK_LOOKUP_BY_NAME.
 func (l *Libvirt) NetworkLookupByName(Name string) (rNet Network, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NetworkLookupByNameArgs {
 		Name: Name,
@@ -5205,7 +5205,7 @@ func (l *Libvirt) NetworkLookupByName(Name string) (rNet Network, err error) {
 	}
 
 	var r response
-	r, err = l.request(46, constants.Program, &buf)
+	r, err = l.request(46, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5224,7 +5224,7 @@ func (l *Libvirt) NetworkLookupByName(Name string) (rNet Network, err error) {
 
 // NetworkLookupByUUID is the go wrapper for REMOTE_PROC_NETWORK_LOOKUP_BY_UUID.
 func (l *Libvirt) NetworkLookupByUUID(UUID UUID) (rNet Network, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NetworkLookupByUUIDArgs {
 		UUID: UUID,
@@ -5236,7 +5236,7 @@ func (l *Libvirt) NetworkLookupByUUID(UUID UUID) (rNet Network, err error) {
 	}
 
 	var r response
-	r, err = l.request(47, constants.Program, &buf)
+	r, err = l.request(47, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5255,7 +5255,7 @@ func (l *Libvirt) NetworkLookupByUUID(UUID UUID) (rNet Network, err error) {
 
 // NetworkSetAutostart is the go wrapper for REMOTE_PROC_NETWORK_SET_AUTOSTART.
 func (l *Libvirt) NetworkSetAutostart(Net Network, Autostart int32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NetworkSetAutostartArgs {
 		Net: Net,
@@ -5268,7 +5268,7 @@ func (l *Libvirt) NetworkSetAutostart(Net Network, Autostart int32) (err error) 
 	}
 
 
-	_, err = l.request(48, constants.Program, &buf)
+	_, err = l.request(48, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5278,7 +5278,7 @@ func (l *Libvirt) NetworkSetAutostart(Net Network, Autostart int32) (err error) 
 
 // NetworkUndefine is the go wrapper for REMOTE_PROC_NETWORK_UNDEFINE.
 func (l *Libvirt) NetworkUndefine(Net Network) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NetworkUndefineArgs {
 		Net: Net,
@@ -5290,7 +5290,7 @@ func (l *Libvirt) NetworkUndefine(Net Network) (err error) {
 	}
 
 
-	_, err = l.request(49, constants.Program, &buf)
+	_, err = l.request(49, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5300,10 +5300,10 @@ func (l *Libvirt) NetworkUndefine(Net Network) (err error) {
 
 // ConnectNumOfDefinedNetworks is the go wrapper for REMOTE_PROC_CONNECT_NUM_OF_DEFINED_NETWORKS.
 func (l *Libvirt) ConnectNumOfDefinedNetworks() (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(50, constants.Program, &buf)
+	r, err = l.request(50, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5322,10 +5322,10 @@ func (l *Libvirt) ConnectNumOfDefinedNetworks() (rNum int32, err error) {
 
 // ConnectNumOfDomains is the go wrapper for REMOTE_PROC_CONNECT_NUM_OF_DOMAINS.
 func (l *Libvirt) ConnectNumOfDomains() (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(51, constants.Program, &buf)
+	r, err = l.request(51, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5344,10 +5344,10 @@ func (l *Libvirt) ConnectNumOfDomains() (rNum int32, err error) {
 
 // ConnectNumOfNetworks is the go wrapper for REMOTE_PROC_CONNECT_NUM_OF_NETWORKS.
 func (l *Libvirt) ConnectNumOfNetworks() (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(52, constants.Program, &buf)
+	r, err = l.request(52, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5366,7 +5366,7 @@ func (l *Libvirt) ConnectNumOfNetworks() (rNum int32, err error) {
 
 // DomainCoreDump is the go wrapper for REMOTE_PROC_DOMAIN_CORE_DUMP.
 func (l *Libvirt) DomainCoreDump(Dom Domain, To string, Flags DomainCoreDumpFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainCoreDumpArgs {
 		Dom: Dom,
@@ -5380,7 +5380,7 @@ func (l *Libvirt) DomainCoreDump(Dom Domain, To string, Flags DomainCoreDumpFlag
 	}
 
 
-	_, err = l.request(53, constants.Program, &buf)
+	_, err = l.request(53, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5390,7 +5390,7 @@ func (l *Libvirt) DomainCoreDump(Dom Domain, To string, Flags DomainCoreDumpFlag
 
 // DomainRestore is the go wrapper for REMOTE_PROC_DOMAIN_RESTORE.
 func (l *Libvirt) DomainRestore(From string) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainRestoreArgs {
 		From: From,
@@ -5402,7 +5402,7 @@ func (l *Libvirt) DomainRestore(From string) (err error) {
 	}
 
 
-	_, err = l.request(54, constants.Program, &buf)
+	_, err = l.request(54, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5412,7 +5412,7 @@ func (l *Libvirt) DomainRestore(From string) (err error) {
 
 // DomainSave is the go wrapper for REMOTE_PROC_DOMAIN_SAVE.
 func (l *Libvirt) DomainSave(Dom Domain, To string) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSaveArgs {
 		Dom: Dom,
@@ -5425,7 +5425,7 @@ func (l *Libvirt) DomainSave(Dom Domain, To string) (err error) {
 	}
 
 
-	_, err = l.request(55, constants.Program, &buf)
+	_, err = l.request(55, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5435,7 +5435,7 @@ func (l *Libvirt) DomainSave(Dom Domain, To string) (err error) {
 
 // DomainGetSchedulerType is the go wrapper for REMOTE_PROC_DOMAIN_GET_SCHEDULER_TYPE.
 func (l *Libvirt) DomainGetSchedulerType(Dom Domain) (rType string, rNparams int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetSchedulerTypeArgs {
 		Dom: Dom,
@@ -5447,7 +5447,7 @@ func (l *Libvirt) DomainGetSchedulerType(Dom Domain) (rType string, rNparams int
 	}
 
 	var r response
-	r, err = l.request(56, constants.Program, &buf)
+	r, err = l.request(56, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5471,7 +5471,7 @@ func (l *Libvirt) DomainGetSchedulerType(Dom Domain) (rType string, rNparams int
 
 // DomainGetSchedulerParameters is the go wrapper for REMOTE_PROC_DOMAIN_GET_SCHEDULER_PARAMETERS.
 func (l *Libvirt) DomainGetSchedulerParameters(Dom Domain, Nparams int32) (rParams []TypedParam, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetSchedulerParametersArgs {
 		Dom: Dom,
@@ -5484,7 +5484,7 @@ func (l *Libvirt) DomainGetSchedulerParameters(Dom Domain, Nparams int32) (rPara
 	}
 
 	var r response
-	r, err = l.request(57, constants.Program, &buf)
+	r, err = l.request(57, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5504,7 +5504,7 @@ func (l *Libvirt) DomainGetSchedulerParameters(Dom Domain, Nparams int32) (rPara
 
 // DomainSetSchedulerParameters is the go wrapper for REMOTE_PROC_DOMAIN_SET_SCHEDULER_PARAMETERS.
 func (l *Libvirt) DomainSetSchedulerParameters(Dom Domain, Params []TypedParam) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetSchedulerParametersArgs {
 		Dom: Dom,
@@ -5517,7 +5517,7 @@ func (l *Libvirt) DomainSetSchedulerParameters(Dom Domain, Params []TypedParam) 
 	}
 
 
-	_, err = l.request(58, constants.Program, &buf)
+	_, err = l.request(58, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5527,10 +5527,10 @@ func (l *Libvirt) DomainSetSchedulerParameters(Dom Domain, Params []TypedParam) 
 
 // ConnectGetHostname is the go wrapper for REMOTE_PROC_CONNECT_GET_HOSTNAME.
 func (l *Libvirt) ConnectGetHostname() (rHostname string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(59, constants.Program, &buf)
+	r, err = l.request(59, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5549,7 +5549,7 @@ func (l *Libvirt) ConnectGetHostname() (rHostname string, err error) {
 
 // ConnectSupportsFeature is the go wrapper for REMOTE_PROC_CONNECT_SUPPORTS_FEATURE.
 func (l *Libvirt) ConnectSupportsFeature(Feature int32) (rSupported int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectSupportsFeatureArgs {
 		Feature: Feature,
@@ -5561,7 +5561,7 @@ func (l *Libvirt) ConnectSupportsFeature(Feature int32) (rSupported int32, err e
 	}
 
 	var r response
-	r, err = l.request(60, constants.Program, &buf)
+	r, err = l.request(60, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5580,7 +5580,7 @@ func (l *Libvirt) ConnectSupportsFeature(Feature int32) (rSupported int32, err e
 
 // DomainMigratePrepare is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_PREPARE.
 func (l *Libvirt) DomainMigratePrepare(UriIn OptString, Flags uint64, Dname OptString, Resource uint64) (rCookie []byte, rUriOut OptString, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigratePrepareArgs {
 		UriIn: UriIn,
@@ -5595,7 +5595,7 @@ func (l *Libvirt) DomainMigratePrepare(UriIn OptString, Flags uint64, Dname OptS
 	}
 
 	var r response
-	r, err = l.request(61, constants.Program, &buf)
+	r, err = l.request(61, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5619,7 +5619,7 @@ func (l *Libvirt) DomainMigratePrepare(UriIn OptString, Flags uint64, Dname OptS
 
 // DomainMigratePerform is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_PERFORM.
 func (l *Libvirt) DomainMigratePerform(Dom Domain, Cookie []byte, Uri string, Flags uint64, Dname OptString, Resource uint64) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigratePerformArgs {
 		Dom: Dom,
@@ -5636,7 +5636,7 @@ func (l *Libvirt) DomainMigratePerform(Dom Domain, Cookie []byte, Uri string, Fl
 	}
 
 
-	_, err = l.request(62, constants.Program, &buf)
+	_, err = l.request(62, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5646,7 +5646,7 @@ func (l *Libvirt) DomainMigratePerform(Dom Domain, Cookie []byte, Uri string, Fl
 
 // DomainMigrateFinish is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_FINISH.
 func (l *Libvirt) DomainMigrateFinish(Dname string, Cookie []byte, Uri string, Flags uint64) (rDdom Domain, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigrateFinishArgs {
 		Dname: Dname,
@@ -5661,7 +5661,7 @@ func (l *Libvirt) DomainMigrateFinish(Dname string, Cookie []byte, Uri string, F
 	}
 
 	var r response
-	r, err = l.request(63, constants.Program, &buf)
+	r, err = l.request(63, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5680,7 +5680,7 @@ func (l *Libvirt) DomainMigrateFinish(Dname string, Cookie []byte, Uri string, F
 
 // DomainBlockStats is the go wrapper for REMOTE_PROC_DOMAIN_BLOCK_STATS.
 func (l *Libvirt) DomainBlockStats(Dom Domain, Path string) (rRdReq int64, rRdBytes int64, rWrReq int64, rWrBytes int64, rErrs int64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainBlockStatsArgs {
 		Dom: Dom,
@@ -5693,7 +5693,7 @@ func (l *Libvirt) DomainBlockStats(Dom Domain, Path string) (rRdReq int64, rRdBy
 	}
 
 	var r response
-	r, err = l.request(64, constants.Program, &buf)
+	r, err = l.request(64, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5732,7 +5732,7 @@ func (l *Libvirt) DomainBlockStats(Dom Domain, Path string) (rRdReq int64, rRdBy
 
 // DomainInterfaceStats is the go wrapper for REMOTE_PROC_DOMAIN_INTERFACE_STATS.
 func (l *Libvirt) DomainInterfaceStats(Dom Domain, Device string) (rRxBytes int64, rRxPackets int64, rRxErrs int64, rRxDrop int64, rTxBytes int64, rTxPackets int64, rTxErrs int64, rTxDrop int64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainInterfaceStatsArgs {
 		Dom: Dom,
@@ -5745,7 +5745,7 @@ func (l *Libvirt) DomainInterfaceStats(Dom Domain, Device string) (rRxBytes int6
 	}
 
 	var r response
-	r, err = l.request(65, constants.Program, &buf)
+	r, err = l.request(65, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5799,10 +5799,10 @@ func (l *Libvirt) DomainInterfaceStats(Dom Domain, Device string) (rRxBytes int6
 
 // AuthList is the go wrapper for REMOTE_PROC_AUTH_LIST.
 func (l *Libvirt) AuthList() (rTypes []AuthType, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(66, constants.Program, &buf)
+	r, err = l.request(66, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5821,10 +5821,10 @@ func (l *Libvirt) AuthList() (rTypes []AuthType, err error) {
 
 // AuthSaslInit is the go wrapper for REMOTE_PROC_AUTH_SASL_INIT.
 func (l *Libvirt) AuthSaslInit() (rMechlist string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(67, constants.Program, &buf)
+	r, err = l.request(67, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5843,7 +5843,7 @@ func (l *Libvirt) AuthSaslInit() (rMechlist string, err error) {
 
 // AuthSaslStart is the go wrapper for REMOTE_PROC_AUTH_SASL_START.
 func (l *Libvirt) AuthSaslStart(Mech string, Nil int32, Data []int8) (rComplete int32, rNil int32, rData []int8, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := AuthSaslStartArgs {
 		Mech: Mech,
@@ -5857,7 +5857,7 @@ func (l *Libvirt) AuthSaslStart(Mech string, Nil int32, Data []int8) (rComplete 
 	}
 
 	var r response
-	r, err = l.request(68, constants.Program, &buf)
+	r, err = l.request(68, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5886,7 +5886,7 @@ func (l *Libvirt) AuthSaslStart(Mech string, Nil int32, Data []int8) (rComplete 
 
 // AuthSaslStep is the go wrapper for REMOTE_PROC_AUTH_SASL_STEP.
 func (l *Libvirt) AuthSaslStep(Nil int32, Data []int8) (rComplete int32, rNil int32, rData []int8, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := AuthSaslStepArgs {
 		Nil: Nil,
@@ -5899,7 +5899,7 @@ func (l *Libvirt) AuthSaslStep(Nil int32, Data []int8) (rComplete int32, rNil in
 	}
 
 	var r response
-	r, err = l.request(69, constants.Program, &buf)
+	r, err = l.request(69, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5928,10 +5928,10 @@ func (l *Libvirt) AuthSaslStep(Nil int32, Data []int8) (rComplete int32, rNil in
 
 // AuthPolkit is the go wrapper for REMOTE_PROC_AUTH_POLKIT.
 func (l *Libvirt) AuthPolkit() (rComplete int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(70, constants.Program, &buf)
+	r, err = l.request(70, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5950,10 +5950,10 @@ func (l *Libvirt) AuthPolkit() (rComplete int32, err error) {
 
 // ConnectNumOfStoragePools is the go wrapper for REMOTE_PROC_CONNECT_NUM_OF_STORAGE_POOLS.
 func (l *Libvirt) ConnectNumOfStoragePools() (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(71, constants.Program, &buf)
+	r, err = l.request(71, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -5972,7 +5972,7 @@ func (l *Libvirt) ConnectNumOfStoragePools() (rNum int32, err error) {
 
 // ConnectListStoragePools is the go wrapper for REMOTE_PROC_CONNECT_LIST_STORAGE_POOLS.
 func (l *Libvirt) ConnectListStoragePools(Maxnames int32) (rNames []string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListStoragePoolsArgs {
 		Maxnames: Maxnames,
@@ -5984,7 +5984,7 @@ func (l *Libvirt) ConnectListStoragePools(Maxnames int32) (rNames []string, err 
 	}
 
 	var r response
-	r, err = l.request(72, constants.Program, &buf)
+	r, err = l.request(72, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6003,10 +6003,10 @@ func (l *Libvirt) ConnectListStoragePools(Maxnames int32) (rNames []string, err 
 
 // ConnectNumOfDefinedStoragePools is the go wrapper for REMOTE_PROC_CONNECT_NUM_OF_DEFINED_STORAGE_POOLS.
 func (l *Libvirt) ConnectNumOfDefinedStoragePools() (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(73, constants.Program, &buf)
+	r, err = l.request(73, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6025,7 +6025,7 @@ func (l *Libvirt) ConnectNumOfDefinedStoragePools() (rNum int32, err error) {
 
 // ConnectListDefinedStoragePools is the go wrapper for REMOTE_PROC_CONNECT_LIST_DEFINED_STORAGE_POOLS.
 func (l *Libvirt) ConnectListDefinedStoragePools(Maxnames int32) (rNames []string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListDefinedStoragePoolsArgs {
 		Maxnames: Maxnames,
@@ -6037,7 +6037,7 @@ func (l *Libvirt) ConnectListDefinedStoragePools(Maxnames int32) (rNames []strin
 	}
 
 	var r response
-	r, err = l.request(74, constants.Program, &buf)
+	r, err = l.request(74, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6056,7 +6056,7 @@ func (l *Libvirt) ConnectListDefinedStoragePools(Maxnames int32) (rNames []strin
 
 // ConnectFindStoragePoolSources is the go wrapper for REMOTE_PROC_CONNECT_FIND_STORAGE_POOL_SOURCES.
 func (l *Libvirt) ConnectFindStoragePoolSources(Type string, SrcSpec OptString, Flags uint32) (rXML string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectFindStoragePoolSourcesArgs {
 		Type: Type,
@@ -6070,7 +6070,7 @@ func (l *Libvirt) ConnectFindStoragePoolSources(Type string, SrcSpec OptString, 
 	}
 
 	var r response
-	r, err = l.request(75, constants.Program, &buf)
+	r, err = l.request(75, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6089,7 +6089,7 @@ func (l *Libvirt) ConnectFindStoragePoolSources(Type string, SrcSpec OptString, 
 
 // StoragePoolCreateXML is the go wrapper for REMOTE_PROC_STORAGE_POOL_CREATE_XML.
 func (l *Libvirt) StoragePoolCreateXML(XML string, Flags StoragePoolCreateFlags) (rPool StoragePool, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolCreateXMLArgs {
 		XML: XML,
@@ -6102,7 +6102,7 @@ func (l *Libvirt) StoragePoolCreateXML(XML string, Flags StoragePoolCreateFlags)
 	}
 
 	var r response
-	r, err = l.request(76, constants.Program, &buf)
+	r, err = l.request(76, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6121,7 +6121,7 @@ func (l *Libvirt) StoragePoolCreateXML(XML string, Flags StoragePoolCreateFlags)
 
 // StoragePoolDefineXML is the go wrapper for REMOTE_PROC_STORAGE_POOL_DEFINE_XML.
 func (l *Libvirt) StoragePoolDefineXML(XML string, Flags uint32) (rPool StoragePool, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolDefineXMLArgs {
 		XML: XML,
@@ -6134,7 +6134,7 @@ func (l *Libvirt) StoragePoolDefineXML(XML string, Flags uint32) (rPool StorageP
 	}
 
 	var r response
-	r, err = l.request(77, constants.Program, &buf)
+	r, err = l.request(77, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6153,7 +6153,7 @@ func (l *Libvirt) StoragePoolDefineXML(XML string, Flags uint32) (rPool StorageP
 
 // StoragePoolCreate is the go wrapper for REMOTE_PROC_STORAGE_POOL_CREATE.
 func (l *Libvirt) StoragePoolCreate(Pool StoragePool, Flags StoragePoolCreateFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolCreateArgs {
 		Pool: Pool,
@@ -6166,7 +6166,7 @@ func (l *Libvirt) StoragePoolCreate(Pool StoragePool, Flags StoragePoolCreateFla
 	}
 
 
-	_, err = l.request(78, constants.Program, &buf)
+	_, err = l.request(78, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6176,7 +6176,7 @@ func (l *Libvirt) StoragePoolCreate(Pool StoragePool, Flags StoragePoolCreateFla
 
 // StoragePoolBuild is the go wrapper for REMOTE_PROC_STORAGE_POOL_BUILD.
 func (l *Libvirt) StoragePoolBuild(Pool StoragePool, Flags StoragePoolBuildFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolBuildArgs {
 		Pool: Pool,
@@ -6189,7 +6189,7 @@ func (l *Libvirt) StoragePoolBuild(Pool StoragePool, Flags StoragePoolBuildFlags
 	}
 
 
-	_, err = l.request(79, constants.Program, &buf)
+	_, err = l.request(79, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6199,7 +6199,7 @@ func (l *Libvirt) StoragePoolBuild(Pool StoragePool, Flags StoragePoolBuildFlags
 
 // StoragePoolDestroy is the go wrapper for REMOTE_PROC_STORAGE_POOL_DESTROY.
 func (l *Libvirt) StoragePoolDestroy(Pool StoragePool) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolDestroyArgs {
 		Pool: Pool,
@@ -6211,7 +6211,7 @@ func (l *Libvirt) StoragePoolDestroy(Pool StoragePool) (err error) {
 	}
 
 
-	_, err = l.request(80, constants.Program, &buf)
+	_, err = l.request(80, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6221,7 +6221,7 @@ func (l *Libvirt) StoragePoolDestroy(Pool StoragePool) (err error) {
 
 // StoragePoolDelete is the go wrapper for REMOTE_PROC_STORAGE_POOL_DELETE.
 func (l *Libvirt) StoragePoolDelete(Pool StoragePool, Flags StoragePoolDeleteFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolDeleteArgs {
 		Pool: Pool,
@@ -6234,7 +6234,7 @@ func (l *Libvirt) StoragePoolDelete(Pool StoragePool, Flags StoragePoolDeleteFla
 	}
 
 
-	_, err = l.request(81, constants.Program, &buf)
+	_, err = l.request(81, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6244,7 +6244,7 @@ func (l *Libvirt) StoragePoolDelete(Pool StoragePool, Flags StoragePoolDeleteFla
 
 // StoragePoolUndefine is the go wrapper for REMOTE_PROC_STORAGE_POOL_UNDEFINE.
 func (l *Libvirt) StoragePoolUndefine(Pool StoragePool) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolUndefineArgs {
 		Pool: Pool,
@@ -6256,7 +6256,7 @@ func (l *Libvirt) StoragePoolUndefine(Pool StoragePool) (err error) {
 	}
 
 
-	_, err = l.request(82, constants.Program, &buf)
+	_, err = l.request(82, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6266,7 +6266,7 @@ func (l *Libvirt) StoragePoolUndefine(Pool StoragePool) (err error) {
 
 // StoragePoolRefresh is the go wrapper for REMOTE_PROC_STORAGE_POOL_REFRESH.
 func (l *Libvirt) StoragePoolRefresh(Pool StoragePool, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolRefreshArgs {
 		Pool: Pool,
@@ -6279,7 +6279,7 @@ func (l *Libvirt) StoragePoolRefresh(Pool StoragePool, Flags uint32) (err error)
 	}
 
 
-	_, err = l.request(83, constants.Program, &buf)
+	_, err = l.request(83, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6289,7 +6289,7 @@ func (l *Libvirt) StoragePoolRefresh(Pool StoragePool, Flags uint32) (err error)
 
 // StoragePoolLookupByName is the go wrapper for REMOTE_PROC_STORAGE_POOL_LOOKUP_BY_NAME.
 func (l *Libvirt) StoragePoolLookupByName(Name string) (rPool StoragePool, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolLookupByNameArgs {
 		Name: Name,
@@ -6301,7 +6301,7 @@ func (l *Libvirt) StoragePoolLookupByName(Name string) (rPool StoragePool, err e
 	}
 
 	var r response
-	r, err = l.request(84, constants.Program, &buf)
+	r, err = l.request(84, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6320,7 +6320,7 @@ func (l *Libvirt) StoragePoolLookupByName(Name string) (rPool StoragePool, err e
 
 // StoragePoolLookupByUUID is the go wrapper for REMOTE_PROC_STORAGE_POOL_LOOKUP_BY_UUID.
 func (l *Libvirt) StoragePoolLookupByUUID(UUID UUID) (rPool StoragePool, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolLookupByUUIDArgs {
 		UUID: UUID,
@@ -6332,7 +6332,7 @@ func (l *Libvirt) StoragePoolLookupByUUID(UUID UUID) (rPool StoragePool, err err
 	}
 
 	var r response
-	r, err = l.request(85, constants.Program, &buf)
+	r, err = l.request(85, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6351,7 +6351,7 @@ func (l *Libvirt) StoragePoolLookupByUUID(UUID UUID) (rPool StoragePool, err err
 
 // StoragePoolLookupByVolume is the go wrapper for REMOTE_PROC_STORAGE_POOL_LOOKUP_BY_VOLUME.
 func (l *Libvirt) StoragePoolLookupByVolume(Vol StorageVol) (rPool StoragePool, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolLookupByVolumeArgs {
 		Vol: Vol,
@@ -6363,7 +6363,7 @@ func (l *Libvirt) StoragePoolLookupByVolume(Vol StorageVol) (rPool StoragePool, 
 	}
 
 	var r response
-	r, err = l.request(86, constants.Program, &buf)
+	r, err = l.request(86, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6382,7 +6382,7 @@ func (l *Libvirt) StoragePoolLookupByVolume(Vol StorageVol) (rPool StoragePool, 
 
 // StoragePoolGetInfo is the go wrapper for REMOTE_PROC_STORAGE_POOL_GET_INFO.
 func (l *Libvirt) StoragePoolGetInfo(Pool StoragePool) (rState uint8, rCapacity uint64, rAllocation uint64, rAvailable uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolGetInfoArgs {
 		Pool: Pool,
@@ -6394,7 +6394,7 @@ func (l *Libvirt) StoragePoolGetInfo(Pool StoragePool) (rState uint8, rCapacity 
 	}
 
 	var r response
-	r, err = l.request(87, constants.Program, &buf)
+	r, err = l.request(87, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6428,7 +6428,7 @@ func (l *Libvirt) StoragePoolGetInfo(Pool StoragePool) (rState uint8, rCapacity 
 
 // StoragePoolGetXMLDesc is the go wrapper for REMOTE_PROC_STORAGE_POOL_GET_XML_DESC.
 func (l *Libvirt) StoragePoolGetXMLDesc(Pool StoragePool, Flags StorageXMLFlags) (rXML string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolGetXMLDescArgs {
 		Pool: Pool,
@@ -6441,7 +6441,7 @@ func (l *Libvirt) StoragePoolGetXMLDesc(Pool StoragePool, Flags StorageXMLFlags)
 	}
 
 	var r response
-	r, err = l.request(88, constants.Program, &buf)
+	r, err = l.request(88, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6460,7 +6460,7 @@ func (l *Libvirt) StoragePoolGetXMLDesc(Pool StoragePool, Flags StorageXMLFlags)
 
 // StoragePoolGetAutostart is the go wrapper for REMOTE_PROC_STORAGE_POOL_GET_AUTOSTART.
 func (l *Libvirt) StoragePoolGetAutostart(Pool StoragePool) (rAutostart int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolGetAutostartArgs {
 		Pool: Pool,
@@ -6472,7 +6472,7 @@ func (l *Libvirt) StoragePoolGetAutostart(Pool StoragePool) (rAutostart int32, e
 	}
 
 	var r response
-	r, err = l.request(89, constants.Program, &buf)
+	r, err = l.request(89, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6491,7 +6491,7 @@ func (l *Libvirt) StoragePoolGetAutostart(Pool StoragePool) (rAutostart int32, e
 
 // StoragePoolSetAutostart is the go wrapper for REMOTE_PROC_STORAGE_POOL_SET_AUTOSTART.
 func (l *Libvirt) StoragePoolSetAutostart(Pool StoragePool, Autostart int32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolSetAutostartArgs {
 		Pool: Pool,
@@ -6504,7 +6504,7 @@ func (l *Libvirt) StoragePoolSetAutostart(Pool StoragePool, Autostart int32) (er
 	}
 
 
-	_, err = l.request(90, constants.Program, &buf)
+	_, err = l.request(90, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6514,7 +6514,7 @@ func (l *Libvirt) StoragePoolSetAutostart(Pool StoragePool, Autostart int32) (er
 
 // StoragePoolNumOfVolumes is the go wrapper for REMOTE_PROC_STORAGE_POOL_NUM_OF_VOLUMES.
 func (l *Libvirt) StoragePoolNumOfVolumes(Pool StoragePool) (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolNumOfVolumesArgs {
 		Pool: Pool,
@@ -6526,7 +6526,7 @@ func (l *Libvirt) StoragePoolNumOfVolumes(Pool StoragePool) (rNum int32, err err
 	}
 
 	var r response
-	r, err = l.request(91, constants.Program, &buf)
+	r, err = l.request(91, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6545,7 +6545,7 @@ func (l *Libvirt) StoragePoolNumOfVolumes(Pool StoragePool) (rNum int32, err err
 
 // StoragePoolListVolumes is the go wrapper for REMOTE_PROC_STORAGE_POOL_LIST_VOLUMES.
 func (l *Libvirt) StoragePoolListVolumes(Pool StoragePool, Maxnames int32) (rNames []string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolListVolumesArgs {
 		Pool: Pool,
@@ -6558,7 +6558,7 @@ func (l *Libvirt) StoragePoolListVolumes(Pool StoragePool, Maxnames int32) (rNam
 	}
 
 	var r response
-	r, err = l.request(92, constants.Program, &buf)
+	r, err = l.request(92, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6577,7 +6577,7 @@ func (l *Libvirt) StoragePoolListVolumes(Pool StoragePool, Maxnames int32) (rNam
 
 // StorageVolCreateXML is the go wrapper for REMOTE_PROC_STORAGE_VOL_CREATE_XML.
 func (l *Libvirt) StorageVolCreateXML(Pool StoragePool, XML string, Flags StorageVolCreateFlags) (rVol StorageVol, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StorageVolCreateXMLArgs {
 		Pool: Pool,
@@ -6591,7 +6591,7 @@ func (l *Libvirt) StorageVolCreateXML(Pool StoragePool, XML string, Flags Storag
 	}
 
 	var r response
-	r, err = l.request(93, constants.Program, &buf)
+	r, err = l.request(93, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6610,7 +6610,7 @@ func (l *Libvirt) StorageVolCreateXML(Pool StoragePool, XML string, Flags Storag
 
 // StorageVolDelete is the go wrapper for REMOTE_PROC_STORAGE_VOL_DELETE.
 func (l *Libvirt) StorageVolDelete(Vol StorageVol, Flags StorageVolDeleteFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StorageVolDeleteArgs {
 		Vol: Vol,
@@ -6623,7 +6623,7 @@ func (l *Libvirt) StorageVolDelete(Vol StorageVol, Flags StorageVolDeleteFlags) 
 	}
 
 
-	_, err = l.request(94, constants.Program, &buf)
+	_, err = l.request(94, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6633,7 +6633,7 @@ func (l *Libvirt) StorageVolDelete(Vol StorageVol, Flags StorageVolDeleteFlags) 
 
 // StorageVolLookupByName is the go wrapper for REMOTE_PROC_STORAGE_VOL_LOOKUP_BY_NAME.
 func (l *Libvirt) StorageVolLookupByName(Pool StoragePool, Name string) (rVol StorageVol, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StorageVolLookupByNameArgs {
 		Pool: Pool,
@@ -6646,7 +6646,7 @@ func (l *Libvirt) StorageVolLookupByName(Pool StoragePool, Name string) (rVol St
 	}
 
 	var r response
-	r, err = l.request(95, constants.Program, &buf)
+	r, err = l.request(95, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6665,7 +6665,7 @@ func (l *Libvirt) StorageVolLookupByName(Pool StoragePool, Name string) (rVol St
 
 // StorageVolLookupByKey is the go wrapper for REMOTE_PROC_STORAGE_VOL_LOOKUP_BY_KEY.
 func (l *Libvirt) StorageVolLookupByKey(Key string) (rVol StorageVol, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StorageVolLookupByKeyArgs {
 		Key: Key,
@@ -6677,7 +6677,7 @@ func (l *Libvirt) StorageVolLookupByKey(Key string) (rVol StorageVol, err error)
 	}
 
 	var r response
-	r, err = l.request(96, constants.Program, &buf)
+	r, err = l.request(96, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6696,7 +6696,7 @@ func (l *Libvirt) StorageVolLookupByKey(Key string) (rVol StorageVol, err error)
 
 // StorageVolLookupByPath is the go wrapper for REMOTE_PROC_STORAGE_VOL_LOOKUP_BY_PATH.
 func (l *Libvirt) StorageVolLookupByPath(Path string) (rVol StorageVol, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StorageVolLookupByPathArgs {
 		Path: Path,
@@ -6708,7 +6708,7 @@ func (l *Libvirt) StorageVolLookupByPath(Path string) (rVol StorageVol, err erro
 	}
 
 	var r response
-	r, err = l.request(97, constants.Program, &buf)
+	r, err = l.request(97, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6727,7 +6727,7 @@ func (l *Libvirt) StorageVolLookupByPath(Path string) (rVol StorageVol, err erro
 
 // StorageVolGetInfo is the go wrapper for REMOTE_PROC_STORAGE_VOL_GET_INFO.
 func (l *Libvirt) StorageVolGetInfo(Vol StorageVol) (rType int8, rCapacity uint64, rAllocation uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StorageVolGetInfoArgs {
 		Vol: Vol,
@@ -6739,7 +6739,7 @@ func (l *Libvirt) StorageVolGetInfo(Vol StorageVol) (rType int8, rCapacity uint6
 	}
 
 	var r response
-	r, err = l.request(98, constants.Program, &buf)
+	r, err = l.request(98, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6768,7 +6768,7 @@ func (l *Libvirt) StorageVolGetInfo(Vol StorageVol) (rType int8, rCapacity uint6
 
 // StorageVolGetXMLDesc is the go wrapper for REMOTE_PROC_STORAGE_VOL_GET_XML_DESC.
 func (l *Libvirt) StorageVolGetXMLDesc(Vol StorageVol, Flags uint32) (rXML string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StorageVolGetXMLDescArgs {
 		Vol: Vol,
@@ -6781,7 +6781,7 @@ func (l *Libvirt) StorageVolGetXMLDesc(Vol StorageVol, Flags uint32) (rXML strin
 	}
 
 	var r response
-	r, err = l.request(99, constants.Program, &buf)
+	r, err = l.request(99, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6800,7 +6800,7 @@ func (l *Libvirt) StorageVolGetXMLDesc(Vol StorageVol, Flags uint32) (rXML strin
 
 // StorageVolGetPath is the go wrapper for REMOTE_PROC_STORAGE_VOL_GET_PATH.
 func (l *Libvirt) StorageVolGetPath(Vol StorageVol) (rName string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StorageVolGetPathArgs {
 		Vol: Vol,
@@ -6812,7 +6812,7 @@ func (l *Libvirt) StorageVolGetPath(Vol StorageVol) (rName string, err error) {
 	}
 
 	var r response
-	r, err = l.request(100, constants.Program, &buf)
+	r, err = l.request(100, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6831,7 +6831,7 @@ func (l *Libvirt) StorageVolGetPath(Vol StorageVol) (rName string, err error) {
 
 // NodeGetCellsFreeMemory is the go wrapper for REMOTE_PROC_NODE_GET_CELLS_FREE_MEMORY.
 func (l *Libvirt) NodeGetCellsFreeMemory(StartCell int32, Maxcells int32) (rCells []uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeGetCellsFreeMemoryArgs {
 		StartCell: StartCell,
@@ -6844,7 +6844,7 @@ func (l *Libvirt) NodeGetCellsFreeMemory(StartCell int32, Maxcells int32) (rCell
 	}
 
 	var r response
-	r, err = l.request(101, constants.Program, &buf)
+	r, err = l.request(101, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6863,10 +6863,10 @@ func (l *Libvirt) NodeGetCellsFreeMemory(StartCell int32, Maxcells int32) (rCell
 
 // NodeGetFreeMemory is the go wrapper for REMOTE_PROC_NODE_GET_FREE_MEMORY.
 func (l *Libvirt) NodeGetFreeMemory() (rFreeMem uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(102, constants.Program, &buf)
+	r, err = l.request(102, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6885,7 +6885,7 @@ func (l *Libvirt) NodeGetFreeMemory() (rFreeMem uint64, err error) {
 
 // DomainBlockPeek is the go wrapper for REMOTE_PROC_DOMAIN_BLOCK_PEEK.
 func (l *Libvirt) DomainBlockPeek(Dom Domain, Path string, Offset uint64, Size uint32, Flags uint32) (rBuffer []byte, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainBlockPeekArgs {
 		Dom: Dom,
@@ -6901,7 +6901,7 @@ func (l *Libvirt) DomainBlockPeek(Dom Domain, Path string, Offset uint64, Size u
 	}
 
 	var r response
-	r, err = l.request(103, constants.Program, &buf)
+	r, err = l.request(103, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6920,7 +6920,7 @@ func (l *Libvirt) DomainBlockPeek(Dom Domain, Path string, Offset uint64, Size u
 
 // DomainMemoryPeek is the go wrapper for REMOTE_PROC_DOMAIN_MEMORY_PEEK.
 func (l *Libvirt) DomainMemoryPeek(Dom Domain, Offset uint64, Size uint32, Flags DomainMemoryFlags) (rBuffer []byte, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMemoryPeekArgs {
 		Dom: Dom,
@@ -6935,7 +6935,7 @@ func (l *Libvirt) DomainMemoryPeek(Dom Domain, Offset uint64, Size uint32, Flags
 	}
 
 	var r response
-	r, err = l.request(104, constants.Program, &buf)
+	r, err = l.request(104, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6954,10 +6954,10 @@ func (l *Libvirt) DomainMemoryPeek(Dom Domain, Offset uint64, Size uint32, Flags
 
 // ConnectDomainEventRegister is the go wrapper for REMOTE_PROC_CONNECT_DOMAIN_EVENT_REGISTER.
 func (l *Libvirt) ConnectDomainEventRegister() (rCbRegistered int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(105, constants.Program, &buf)
+	r, err = l.request(105, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6976,10 +6976,10 @@ func (l *Libvirt) ConnectDomainEventRegister() (rCbRegistered int32, err error) 
 
 // ConnectDomainEventDeregister is the go wrapper for REMOTE_PROC_CONNECT_DOMAIN_EVENT_DEREGISTER.
 func (l *Libvirt) ConnectDomainEventDeregister() (rCbRegistered int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(106, constants.Program, &buf)
+	r, err = l.request(106, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -6998,10 +6998,10 @@ func (l *Libvirt) ConnectDomainEventDeregister() (rCbRegistered int32, err error
 
 // DomainEventLifecycle is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_LIFECYCLE.
 func (l *Libvirt) DomainEventLifecycle() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(107, constants.Program, &buf)
+	_, err = l.request(107, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7011,7 +7011,7 @@ func (l *Libvirt) DomainEventLifecycle() (err error) {
 
 // DomainMigratePrepare2 is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_PREPARE2.
 func (l *Libvirt) DomainMigratePrepare2(UriIn OptString, Flags uint64, Dname OptString, Resource uint64, DomXML string) (rCookie []byte, rUriOut OptString, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigratePrepare2Args {
 		UriIn: UriIn,
@@ -7027,7 +7027,7 @@ func (l *Libvirt) DomainMigratePrepare2(UriIn OptString, Flags uint64, Dname Opt
 	}
 
 	var r response
-	r, err = l.request(108, constants.Program, &buf)
+	r, err = l.request(108, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7051,7 +7051,7 @@ func (l *Libvirt) DomainMigratePrepare2(UriIn OptString, Flags uint64, Dname Opt
 
 // DomainMigrateFinish2 is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_FINISH2.
 func (l *Libvirt) DomainMigrateFinish2(Dname string, Cookie []byte, Uri string, Flags uint64, Retcode int32) (rDdom Domain, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigrateFinish2Args {
 		Dname: Dname,
@@ -7067,7 +7067,7 @@ func (l *Libvirt) DomainMigrateFinish2(Dname string, Cookie []byte, Uri string, 
 	}
 
 	var r response
-	r, err = l.request(109, constants.Program, &buf)
+	r, err = l.request(109, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7086,10 +7086,10 @@ func (l *Libvirt) DomainMigrateFinish2(Dname string, Cookie []byte, Uri string, 
 
 // ConnectGetUri is the go wrapper for REMOTE_PROC_CONNECT_GET_URI.
 func (l *Libvirt) ConnectGetUri() (rUri string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(110, constants.Program, &buf)
+	r, err = l.request(110, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7108,7 +7108,7 @@ func (l *Libvirt) ConnectGetUri() (rUri string, err error) {
 
 // NodeNumOfDevices is the go wrapper for REMOTE_PROC_NODE_NUM_OF_DEVICES.
 func (l *Libvirt) NodeNumOfDevices(Cap OptString, Flags uint32) (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeNumOfDevicesArgs {
 		Cap: Cap,
@@ -7121,7 +7121,7 @@ func (l *Libvirt) NodeNumOfDevices(Cap OptString, Flags uint32) (rNum int32, err
 	}
 
 	var r response
-	r, err = l.request(111, constants.Program, &buf)
+	r, err = l.request(111, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7140,7 +7140,7 @@ func (l *Libvirt) NodeNumOfDevices(Cap OptString, Flags uint32) (rNum int32, err
 
 // NodeListDevices is the go wrapper for REMOTE_PROC_NODE_LIST_DEVICES.
 func (l *Libvirt) NodeListDevices(Cap OptString, Maxnames int32, Flags uint32) (rNames []string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeListDevicesArgs {
 		Cap: Cap,
@@ -7154,7 +7154,7 @@ func (l *Libvirt) NodeListDevices(Cap OptString, Maxnames int32, Flags uint32) (
 	}
 
 	var r response
-	r, err = l.request(112, constants.Program, &buf)
+	r, err = l.request(112, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7173,7 +7173,7 @@ func (l *Libvirt) NodeListDevices(Cap OptString, Maxnames int32, Flags uint32) (
 
 // NodeDeviceLookupByName is the go wrapper for REMOTE_PROC_NODE_DEVICE_LOOKUP_BY_NAME.
 func (l *Libvirt) NodeDeviceLookupByName(Name string) (rDev NodeDevice, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeDeviceLookupByNameArgs {
 		Name: Name,
@@ -7185,7 +7185,7 @@ func (l *Libvirt) NodeDeviceLookupByName(Name string) (rDev NodeDevice, err erro
 	}
 
 	var r response
-	r, err = l.request(113, constants.Program, &buf)
+	r, err = l.request(113, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7204,7 +7204,7 @@ func (l *Libvirt) NodeDeviceLookupByName(Name string) (rDev NodeDevice, err erro
 
 // NodeDeviceGetXMLDesc is the go wrapper for REMOTE_PROC_NODE_DEVICE_GET_XML_DESC.
 func (l *Libvirt) NodeDeviceGetXMLDesc(Name string, Flags uint32) (rXML string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeDeviceGetXMLDescArgs {
 		Name: Name,
@@ -7217,7 +7217,7 @@ func (l *Libvirt) NodeDeviceGetXMLDesc(Name string, Flags uint32) (rXML string, 
 	}
 
 	var r response
-	r, err = l.request(114, constants.Program, &buf)
+	r, err = l.request(114, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7236,7 +7236,7 @@ func (l *Libvirt) NodeDeviceGetXMLDesc(Name string, Flags uint32) (rXML string, 
 
 // NodeDeviceGetParent is the go wrapper for REMOTE_PROC_NODE_DEVICE_GET_PARENT.
 func (l *Libvirt) NodeDeviceGetParent(Name string) (rParent OptString, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeDeviceGetParentArgs {
 		Name: Name,
@@ -7248,7 +7248,7 @@ func (l *Libvirt) NodeDeviceGetParent(Name string) (rParent OptString, err error
 	}
 
 	var r response
-	r, err = l.request(115, constants.Program, &buf)
+	r, err = l.request(115, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7267,7 +7267,7 @@ func (l *Libvirt) NodeDeviceGetParent(Name string) (rParent OptString, err error
 
 // NodeDeviceNumOfCaps is the go wrapper for REMOTE_PROC_NODE_DEVICE_NUM_OF_CAPS.
 func (l *Libvirt) NodeDeviceNumOfCaps(Name string) (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeDeviceNumOfCapsArgs {
 		Name: Name,
@@ -7279,7 +7279,7 @@ func (l *Libvirt) NodeDeviceNumOfCaps(Name string) (rNum int32, err error) {
 	}
 
 	var r response
-	r, err = l.request(116, constants.Program, &buf)
+	r, err = l.request(116, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7298,7 +7298,7 @@ func (l *Libvirt) NodeDeviceNumOfCaps(Name string) (rNum int32, err error) {
 
 // NodeDeviceListCaps is the go wrapper for REMOTE_PROC_NODE_DEVICE_LIST_CAPS.
 func (l *Libvirt) NodeDeviceListCaps(Name string, Maxnames int32) (rNames []string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeDeviceListCapsArgs {
 		Name: Name,
@@ -7311,7 +7311,7 @@ func (l *Libvirt) NodeDeviceListCaps(Name string, Maxnames int32) (rNames []stri
 	}
 
 	var r response
-	r, err = l.request(117, constants.Program, &buf)
+	r, err = l.request(117, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7330,7 +7330,7 @@ func (l *Libvirt) NodeDeviceListCaps(Name string, Maxnames int32) (rNames []stri
 
 // NodeDeviceDettach is the go wrapper for REMOTE_PROC_NODE_DEVICE_DETTACH.
 func (l *Libvirt) NodeDeviceDettach(Name string) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeDeviceDettachArgs {
 		Name: Name,
@@ -7342,7 +7342,7 @@ func (l *Libvirt) NodeDeviceDettach(Name string) (err error) {
 	}
 
 
-	_, err = l.request(118, constants.Program, &buf)
+	_, err = l.request(118, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7352,7 +7352,7 @@ func (l *Libvirt) NodeDeviceDettach(Name string) (err error) {
 
 // NodeDeviceReAttach is the go wrapper for REMOTE_PROC_NODE_DEVICE_RE_ATTACH.
 func (l *Libvirt) NodeDeviceReAttach(Name string) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeDeviceReAttachArgs {
 		Name: Name,
@@ -7364,7 +7364,7 @@ func (l *Libvirt) NodeDeviceReAttach(Name string) (err error) {
 	}
 
 
-	_, err = l.request(119, constants.Program, &buf)
+	_, err = l.request(119, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7374,7 +7374,7 @@ func (l *Libvirt) NodeDeviceReAttach(Name string) (err error) {
 
 // NodeDeviceReset is the go wrapper for REMOTE_PROC_NODE_DEVICE_RESET.
 func (l *Libvirt) NodeDeviceReset(Name string) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeDeviceResetArgs {
 		Name: Name,
@@ -7386,7 +7386,7 @@ func (l *Libvirt) NodeDeviceReset(Name string) (err error) {
 	}
 
 
-	_, err = l.request(120, constants.Program, &buf)
+	_, err = l.request(120, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7396,7 +7396,7 @@ func (l *Libvirt) NodeDeviceReset(Name string) (err error) {
 
 // DomainGetSecurityLabel is the go wrapper for REMOTE_PROC_DOMAIN_GET_SECURITY_LABEL.
 func (l *Libvirt) DomainGetSecurityLabel(Dom Domain) (rLabel []int8, rEnforcing int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetSecurityLabelArgs {
 		Dom: Dom,
@@ -7408,7 +7408,7 @@ func (l *Libvirt) DomainGetSecurityLabel(Dom Domain) (rLabel []int8, rEnforcing 
 	}
 
 	var r response
-	r, err = l.request(121, constants.Program, &buf)
+	r, err = l.request(121, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7432,10 +7432,10 @@ func (l *Libvirt) DomainGetSecurityLabel(Dom Domain) (rLabel []int8, rEnforcing 
 
 // NodeGetSecurityModel is the go wrapper for REMOTE_PROC_NODE_GET_SECURITY_MODEL.
 func (l *Libvirt) NodeGetSecurityModel() (rModel []int8, rDoi []int8, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(122, constants.Program, &buf)
+	r, err = l.request(122, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7459,7 +7459,7 @@ func (l *Libvirt) NodeGetSecurityModel() (rModel []int8, rDoi []int8, err error)
 
 // NodeDeviceCreateXML is the go wrapper for REMOTE_PROC_NODE_DEVICE_CREATE_XML.
 func (l *Libvirt) NodeDeviceCreateXML(XMLDesc string, Flags uint32) (rDev NodeDevice, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeDeviceCreateXMLArgs {
 		XMLDesc: XMLDesc,
@@ -7472,7 +7472,7 @@ func (l *Libvirt) NodeDeviceCreateXML(XMLDesc string, Flags uint32) (rDev NodeDe
 	}
 
 	var r response
-	r, err = l.request(123, constants.Program, &buf)
+	r, err = l.request(123, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7491,7 +7491,7 @@ func (l *Libvirt) NodeDeviceCreateXML(XMLDesc string, Flags uint32) (rDev NodeDe
 
 // NodeDeviceDestroy is the go wrapper for REMOTE_PROC_NODE_DEVICE_DESTROY.
 func (l *Libvirt) NodeDeviceDestroy(Name string) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeDeviceDestroyArgs {
 		Name: Name,
@@ -7503,7 +7503,7 @@ func (l *Libvirt) NodeDeviceDestroy(Name string) (err error) {
 	}
 
 
-	_, err = l.request(124, constants.Program, &buf)
+	_, err = l.request(124, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7513,7 +7513,7 @@ func (l *Libvirt) NodeDeviceDestroy(Name string) (err error) {
 
 // StorageVolCreateXMLFrom is the go wrapper for REMOTE_PROC_STORAGE_VOL_CREATE_XML_FROM.
 func (l *Libvirt) StorageVolCreateXMLFrom(Pool StoragePool, XML string, Clonevol StorageVol, Flags StorageVolCreateFlags) (rVol StorageVol, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StorageVolCreateXMLFromArgs {
 		Pool: Pool,
@@ -7528,7 +7528,7 @@ func (l *Libvirt) StorageVolCreateXMLFrom(Pool StoragePool, XML string, Clonevol
 	}
 
 	var r response
-	r, err = l.request(125, constants.Program, &buf)
+	r, err = l.request(125, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7547,10 +7547,10 @@ func (l *Libvirt) StorageVolCreateXMLFrom(Pool StoragePool, XML string, Clonevol
 
 // ConnectNumOfInterfaces is the go wrapper for REMOTE_PROC_CONNECT_NUM_OF_INTERFACES.
 func (l *Libvirt) ConnectNumOfInterfaces() (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(126, constants.Program, &buf)
+	r, err = l.request(126, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7569,7 +7569,7 @@ func (l *Libvirt) ConnectNumOfInterfaces() (rNum int32, err error) {
 
 // ConnectListInterfaces is the go wrapper for REMOTE_PROC_CONNECT_LIST_INTERFACES.
 func (l *Libvirt) ConnectListInterfaces(Maxnames int32) (rNames []string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListInterfacesArgs {
 		Maxnames: Maxnames,
@@ -7581,7 +7581,7 @@ func (l *Libvirt) ConnectListInterfaces(Maxnames int32) (rNames []string, err er
 	}
 
 	var r response
-	r, err = l.request(127, constants.Program, &buf)
+	r, err = l.request(127, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7600,7 +7600,7 @@ func (l *Libvirt) ConnectListInterfaces(Maxnames int32) (rNames []string, err er
 
 // InterfaceLookupByName is the go wrapper for REMOTE_PROC_INTERFACE_LOOKUP_BY_NAME.
 func (l *Libvirt) InterfaceLookupByName(Name string) (rIface Interface, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := InterfaceLookupByNameArgs {
 		Name: Name,
@@ -7612,7 +7612,7 @@ func (l *Libvirt) InterfaceLookupByName(Name string) (rIface Interface, err erro
 	}
 
 	var r response
-	r, err = l.request(128, constants.Program, &buf)
+	r, err = l.request(128, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7631,7 +7631,7 @@ func (l *Libvirt) InterfaceLookupByName(Name string) (rIface Interface, err erro
 
 // InterfaceLookupByMacString is the go wrapper for REMOTE_PROC_INTERFACE_LOOKUP_BY_MAC_STRING.
 func (l *Libvirt) InterfaceLookupByMacString(Mac string) (rIface Interface, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := InterfaceLookupByMacStringArgs {
 		Mac: Mac,
@@ -7643,7 +7643,7 @@ func (l *Libvirt) InterfaceLookupByMacString(Mac string) (rIface Interface, err 
 	}
 
 	var r response
-	r, err = l.request(129, constants.Program, &buf)
+	r, err = l.request(129, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7662,7 +7662,7 @@ func (l *Libvirt) InterfaceLookupByMacString(Mac string) (rIface Interface, err 
 
 // InterfaceGetXMLDesc is the go wrapper for REMOTE_PROC_INTERFACE_GET_XML_DESC.
 func (l *Libvirt) InterfaceGetXMLDesc(Iface Interface, Flags uint32) (rXML string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := InterfaceGetXMLDescArgs {
 		Iface: Iface,
@@ -7675,7 +7675,7 @@ func (l *Libvirt) InterfaceGetXMLDesc(Iface Interface, Flags uint32) (rXML strin
 	}
 
 	var r response
-	r, err = l.request(130, constants.Program, &buf)
+	r, err = l.request(130, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7694,7 +7694,7 @@ func (l *Libvirt) InterfaceGetXMLDesc(Iface Interface, Flags uint32) (rXML strin
 
 // InterfaceDefineXML is the go wrapper for REMOTE_PROC_INTERFACE_DEFINE_XML.
 func (l *Libvirt) InterfaceDefineXML(XML string, Flags uint32) (rIface Interface, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := InterfaceDefineXMLArgs {
 		XML: XML,
@@ -7707,7 +7707,7 @@ func (l *Libvirt) InterfaceDefineXML(XML string, Flags uint32) (rIface Interface
 	}
 
 	var r response
-	r, err = l.request(131, constants.Program, &buf)
+	r, err = l.request(131, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7726,7 +7726,7 @@ func (l *Libvirt) InterfaceDefineXML(XML string, Flags uint32) (rIface Interface
 
 // InterfaceUndefine is the go wrapper for REMOTE_PROC_INTERFACE_UNDEFINE.
 func (l *Libvirt) InterfaceUndefine(Iface Interface) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := InterfaceUndefineArgs {
 		Iface: Iface,
@@ -7738,7 +7738,7 @@ func (l *Libvirt) InterfaceUndefine(Iface Interface) (err error) {
 	}
 
 
-	_, err = l.request(132, constants.Program, &buf)
+	_, err = l.request(132, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7748,7 +7748,7 @@ func (l *Libvirt) InterfaceUndefine(Iface Interface) (err error) {
 
 // InterfaceCreate is the go wrapper for REMOTE_PROC_INTERFACE_CREATE.
 func (l *Libvirt) InterfaceCreate(Iface Interface, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := InterfaceCreateArgs {
 		Iface: Iface,
@@ -7761,7 +7761,7 @@ func (l *Libvirt) InterfaceCreate(Iface Interface, Flags uint32) (err error) {
 	}
 
 
-	_, err = l.request(133, constants.Program, &buf)
+	_, err = l.request(133, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7771,7 +7771,7 @@ func (l *Libvirt) InterfaceCreate(Iface Interface, Flags uint32) (err error) {
 
 // InterfaceDestroy is the go wrapper for REMOTE_PROC_INTERFACE_DESTROY.
 func (l *Libvirt) InterfaceDestroy(Iface Interface, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := InterfaceDestroyArgs {
 		Iface: Iface,
@@ -7784,7 +7784,7 @@ func (l *Libvirt) InterfaceDestroy(Iface Interface, Flags uint32) (err error) {
 	}
 
 
-	_, err = l.request(134, constants.Program, &buf)
+	_, err = l.request(134, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7794,7 +7794,7 @@ func (l *Libvirt) InterfaceDestroy(Iface Interface, Flags uint32) (err error) {
 
 // ConnectDomainXMLFromNative is the go wrapper for REMOTE_PROC_CONNECT_DOMAIN_XML_FROM_NATIVE.
 func (l *Libvirt) ConnectDomainXMLFromNative(NativeFormat string, NativeConfig string, Flags uint32) (rDomainXML string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectDomainXMLFromNativeArgs {
 		NativeFormat: NativeFormat,
@@ -7808,7 +7808,7 @@ func (l *Libvirt) ConnectDomainXMLFromNative(NativeFormat string, NativeConfig s
 	}
 
 	var r response
-	r, err = l.request(135, constants.Program, &buf)
+	r, err = l.request(135, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7827,7 +7827,7 @@ func (l *Libvirt) ConnectDomainXMLFromNative(NativeFormat string, NativeConfig s
 
 // ConnectDomainXMLToNative is the go wrapper for REMOTE_PROC_CONNECT_DOMAIN_XML_TO_NATIVE.
 func (l *Libvirt) ConnectDomainXMLToNative(NativeFormat string, DomainXML string, Flags uint32) (rNativeConfig string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectDomainXMLToNativeArgs {
 		NativeFormat: NativeFormat,
@@ -7841,7 +7841,7 @@ func (l *Libvirt) ConnectDomainXMLToNative(NativeFormat string, DomainXML string
 	}
 
 	var r response
-	r, err = l.request(136, constants.Program, &buf)
+	r, err = l.request(136, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7860,10 +7860,10 @@ func (l *Libvirt) ConnectDomainXMLToNative(NativeFormat string, DomainXML string
 
 // ConnectNumOfDefinedInterfaces is the go wrapper for REMOTE_PROC_CONNECT_NUM_OF_DEFINED_INTERFACES.
 func (l *Libvirt) ConnectNumOfDefinedInterfaces() (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(137, constants.Program, &buf)
+	r, err = l.request(137, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7882,7 +7882,7 @@ func (l *Libvirt) ConnectNumOfDefinedInterfaces() (rNum int32, err error) {
 
 // ConnectListDefinedInterfaces is the go wrapper for REMOTE_PROC_CONNECT_LIST_DEFINED_INTERFACES.
 func (l *Libvirt) ConnectListDefinedInterfaces(Maxnames int32) (rNames []string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListDefinedInterfacesArgs {
 		Maxnames: Maxnames,
@@ -7894,7 +7894,7 @@ func (l *Libvirt) ConnectListDefinedInterfaces(Maxnames int32) (rNames []string,
 	}
 
 	var r response
-	r, err = l.request(138, constants.Program, &buf)
+	r, err = l.request(138, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7913,10 +7913,10 @@ func (l *Libvirt) ConnectListDefinedInterfaces(Maxnames int32) (rNames []string,
 
 // ConnectNumOfSecrets is the go wrapper for REMOTE_PROC_CONNECT_NUM_OF_SECRETS.
 func (l *Libvirt) ConnectNumOfSecrets() (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(139, constants.Program, &buf)
+	r, err = l.request(139, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7935,7 +7935,7 @@ func (l *Libvirt) ConnectNumOfSecrets() (rNum int32, err error) {
 
 // ConnectListSecrets is the go wrapper for REMOTE_PROC_CONNECT_LIST_SECRETS.
 func (l *Libvirt) ConnectListSecrets(Maxuuids int32) (rUuids []string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListSecretsArgs {
 		Maxuuids: Maxuuids,
@@ -7947,7 +7947,7 @@ func (l *Libvirt) ConnectListSecrets(Maxuuids int32) (rUuids []string, err error
 	}
 
 	var r response
-	r, err = l.request(140, constants.Program, &buf)
+	r, err = l.request(140, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7966,7 +7966,7 @@ func (l *Libvirt) ConnectListSecrets(Maxuuids int32) (rUuids []string, err error
 
 // SecretLookupByUUID is the go wrapper for REMOTE_PROC_SECRET_LOOKUP_BY_UUID.
 func (l *Libvirt) SecretLookupByUUID(UUID UUID) (rOptSecret Secret, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := SecretLookupByUUIDArgs {
 		UUID: UUID,
@@ -7978,7 +7978,7 @@ func (l *Libvirt) SecretLookupByUUID(UUID UUID) (rOptSecret Secret, err error) {
 	}
 
 	var r response
-	r, err = l.request(141, constants.Program, &buf)
+	r, err = l.request(141, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -7997,7 +7997,7 @@ func (l *Libvirt) SecretLookupByUUID(UUID UUID) (rOptSecret Secret, err error) {
 
 // SecretDefineXML is the go wrapper for REMOTE_PROC_SECRET_DEFINE_XML.
 func (l *Libvirt) SecretDefineXML(XML string, Flags uint32) (rOptSecret Secret, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := SecretDefineXMLArgs {
 		XML: XML,
@@ -8010,7 +8010,7 @@ func (l *Libvirt) SecretDefineXML(XML string, Flags uint32) (rOptSecret Secret, 
 	}
 
 	var r response
-	r, err = l.request(142, constants.Program, &buf)
+	r, err = l.request(142, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8029,7 +8029,7 @@ func (l *Libvirt) SecretDefineXML(XML string, Flags uint32) (rOptSecret Secret, 
 
 // SecretGetXMLDesc is the go wrapper for REMOTE_PROC_SECRET_GET_XML_DESC.
 func (l *Libvirt) SecretGetXMLDesc(OptSecret Secret, Flags uint32) (rXML string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := SecretGetXMLDescArgs {
 		OptSecret: OptSecret,
@@ -8042,7 +8042,7 @@ func (l *Libvirt) SecretGetXMLDesc(OptSecret Secret, Flags uint32) (rXML string,
 	}
 
 	var r response
-	r, err = l.request(143, constants.Program, &buf)
+	r, err = l.request(143, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8061,7 +8061,7 @@ func (l *Libvirt) SecretGetXMLDesc(OptSecret Secret, Flags uint32) (rXML string,
 
 // SecretSetValue is the go wrapper for REMOTE_PROC_SECRET_SET_VALUE.
 func (l *Libvirt) SecretSetValue(OptSecret Secret, Value []byte, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := SecretSetValueArgs {
 		OptSecret: OptSecret,
@@ -8075,7 +8075,7 @@ func (l *Libvirt) SecretSetValue(OptSecret Secret, Value []byte, Flags uint32) (
 	}
 
 
-	_, err = l.request(144, constants.Program, &buf)
+	_, err = l.request(144, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8085,7 +8085,7 @@ func (l *Libvirt) SecretSetValue(OptSecret Secret, Value []byte, Flags uint32) (
 
 // SecretGetValue is the go wrapper for REMOTE_PROC_SECRET_GET_VALUE.
 func (l *Libvirt) SecretGetValue(OptSecret Secret, Flags uint32) (rValue []byte, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := SecretGetValueArgs {
 		OptSecret: OptSecret,
@@ -8098,7 +8098,7 @@ func (l *Libvirt) SecretGetValue(OptSecret Secret, Flags uint32) (rValue []byte,
 	}
 
 	var r response
-	r, err = l.request(145, constants.Program, &buf)
+	r, err = l.request(145, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8117,7 +8117,7 @@ func (l *Libvirt) SecretGetValue(OptSecret Secret, Flags uint32) (rValue []byte,
 
 // SecretUndefine is the go wrapper for REMOTE_PROC_SECRET_UNDEFINE.
 func (l *Libvirt) SecretUndefine(OptSecret Secret) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := SecretUndefineArgs {
 		OptSecret: OptSecret,
@@ -8129,7 +8129,7 @@ func (l *Libvirt) SecretUndefine(OptSecret Secret) (err error) {
 	}
 
 
-	_, err = l.request(146, constants.Program, &buf)
+	_, err = l.request(146, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8139,7 +8139,7 @@ func (l *Libvirt) SecretUndefine(OptSecret Secret) (err error) {
 
 // SecretLookupByUsage is the go wrapper for REMOTE_PROC_SECRET_LOOKUP_BY_USAGE.
 func (l *Libvirt) SecretLookupByUsage(UsageType int32, UsageID string) (rOptSecret Secret, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := SecretLookupByUsageArgs {
 		UsageType: UsageType,
@@ -8152,7 +8152,7 @@ func (l *Libvirt) SecretLookupByUsage(UsageType int32, UsageID string) (rOptSecr
 	}
 
 	var r response
-	r, err = l.request(147, constants.Program, &buf)
+	r, err = l.request(147, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8171,7 +8171,7 @@ func (l *Libvirt) SecretLookupByUsage(UsageType int32, UsageID string) (rOptSecr
 
 // DomainMigratePrepareTunnel is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_PREPARE_TUNNEL.
 func (l *Libvirt) DomainMigratePrepareTunnel(Flags uint64, Dname OptString, Resource uint64, DomXML string) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigratePrepareTunnelArgs {
 		Flags: Flags,
@@ -8186,7 +8186,7 @@ func (l *Libvirt) DomainMigratePrepareTunnel(Flags uint64, Dname OptString, Reso
 	}
 
 
-	_, err = l.request(148, constants.Program, &buf)
+	_, err = l.request(148, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8196,10 +8196,10 @@ func (l *Libvirt) DomainMigratePrepareTunnel(Flags uint64, Dname OptString, Reso
 
 // ConnectIsSecure is the go wrapper for REMOTE_PROC_CONNECT_IS_SECURE.
 func (l *Libvirt) ConnectIsSecure() (rSecure int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(149, constants.Program, &buf)
+	r, err = l.request(149, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8218,7 +8218,7 @@ func (l *Libvirt) ConnectIsSecure() (rSecure int32, err error) {
 
 // DomainIsActive is the go wrapper for REMOTE_PROC_DOMAIN_IS_ACTIVE.
 func (l *Libvirt) DomainIsActive(Dom Domain) (rActive int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainIsActiveArgs {
 		Dom: Dom,
@@ -8230,7 +8230,7 @@ func (l *Libvirt) DomainIsActive(Dom Domain) (rActive int32, err error) {
 	}
 
 	var r response
-	r, err = l.request(150, constants.Program, &buf)
+	r, err = l.request(150, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8249,7 +8249,7 @@ func (l *Libvirt) DomainIsActive(Dom Domain) (rActive int32, err error) {
 
 // DomainIsPersistent is the go wrapper for REMOTE_PROC_DOMAIN_IS_PERSISTENT.
 func (l *Libvirt) DomainIsPersistent(Dom Domain) (rPersistent int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainIsPersistentArgs {
 		Dom: Dom,
@@ -8261,7 +8261,7 @@ func (l *Libvirt) DomainIsPersistent(Dom Domain) (rPersistent int32, err error) 
 	}
 
 	var r response
-	r, err = l.request(151, constants.Program, &buf)
+	r, err = l.request(151, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8280,7 +8280,7 @@ func (l *Libvirt) DomainIsPersistent(Dom Domain) (rPersistent int32, err error) 
 
 // NetworkIsActive is the go wrapper for REMOTE_PROC_NETWORK_IS_ACTIVE.
 func (l *Libvirt) NetworkIsActive(Net Network) (rActive int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NetworkIsActiveArgs {
 		Net: Net,
@@ -8292,7 +8292,7 @@ func (l *Libvirt) NetworkIsActive(Net Network) (rActive int32, err error) {
 	}
 
 	var r response
-	r, err = l.request(152, constants.Program, &buf)
+	r, err = l.request(152, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8311,7 +8311,7 @@ func (l *Libvirt) NetworkIsActive(Net Network) (rActive int32, err error) {
 
 // NetworkIsPersistent is the go wrapper for REMOTE_PROC_NETWORK_IS_PERSISTENT.
 func (l *Libvirt) NetworkIsPersistent(Net Network) (rPersistent int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NetworkIsPersistentArgs {
 		Net: Net,
@@ -8323,7 +8323,7 @@ func (l *Libvirt) NetworkIsPersistent(Net Network) (rPersistent int32, err error
 	}
 
 	var r response
-	r, err = l.request(153, constants.Program, &buf)
+	r, err = l.request(153, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8342,7 +8342,7 @@ func (l *Libvirt) NetworkIsPersistent(Net Network) (rPersistent int32, err error
 
 // StoragePoolIsActive is the go wrapper for REMOTE_PROC_STORAGE_POOL_IS_ACTIVE.
 func (l *Libvirt) StoragePoolIsActive(Pool StoragePool) (rActive int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolIsActiveArgs {
 		Pool: Pool,
@@ -8354,7 +8354,7 @@ func (l *Libvirt) StoragePoolIsActive(Pool StoragePool) (rActive int32, err erro
 	}
 
 	var r response
-	r, err = l.request(154, constants.Program, &buf)
+	r, err = l.request(154, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8373,7 +8373,7 @@ func (l *Libvirt) StoragePoolIsActive(Pool StoragePool) (rActive int32, err erro
 
 // StoragePoolIsPersistent is the go wrapper for REMOTE_PROC_STORAGE_POOL_IS_PERSISTENT.
 func (l *Libvirt) StoragePoolIsPersistent(Pool StoragePool) (rPersistent int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolIsPersistentArgs {
 		Pool: Pool,
@@ -8385,7 +8385,7 @@ func (l *Libvirt) StoragePoolIsPersistent(Pool StoragePool) (rPersistent int32, 
 	}
 
 	var r response
-	r, err = l.request(155, constants.Program, &buf)
+	r, err = l.request(155, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8404,7 +8404,7 @@ func (l *Libvirt) StoragePoolIsPersistent(Pool StoragePool) (rPersistent int32, 
 
 // InterfaceIsActive is the go wrapper for REMOTE_PROC_INTERFACE_IS_ACTIVE.
 func (l *Libvirt) InterfaceIsActive(Iface Interface) (rActive int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := InterfaceIsActiveArgs {
 		Iface: Iface,
@@ -8416,7 +8416,7 @@ func (l *Libvirt) InterfaceIsActive(Iface Interface) (rActive int32, err error) 
 	}
 
 	var r response
-	r, err = l.request(156, constants.Program, &buf)
+	r, err = l.request(156, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8435,10 +8435,10 @@ func (l *Libvirt) InterfaceIsActive(Iface Interface) (rActive int32, err error) 
 
 // ConnectGetLibVersion is the go wrapper for REMOTE_PROC_CONNECT_GET_LIB_VERSION.
 func (l *Libvirt) ConnectGetLibVersion() (rLibVer uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(157, constants.Program, &buf)
+	r, err = l.request(157, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8457,7 +8457,7 @@ func (l *Libvirt) ConnectGetLibVersion() (rLibVer uint64, err error) {
 
 // ConnectCompareCPU is the go wrapper for REMOTE_PROC_CONNECT_COMPARE_CPU.
 func (l *Libvirt) ConnectCompareCPU(XML string, Flags ConnectCompareCPUFlags) (rResult int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectCompareCPUArgs {
 		XML: XML,
@@ -8470,7 +8470,7 @@ func (l *Libvirt) ConnectCompareCPU(XML string, Flags ConnectCompareCPUFlags) (r
 	}
 
 	var r response
-	r, err = l.request(158, constants.Program, &buf)
+	r, err = l.request(158, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8489,7 +8489,7 @@ func (l *Libvirt) ConnectCompareCPU(XML string, Flags ConnectCompareCPUFlags) (r
 
 // DomainMemoryStats is the go wrapper for REMOTE_PROC_DOMAIN_MEMORY_STATS.
 func (l *Libvirt) DomainMemoryStats(Dom Domain, MaxStats uint32, Flags uint32) (rStats []DomainMemoryStat, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMemoryStatsArgs {
 		Dom: Dom,
@@ -8503,7 +8503,7 @@ func (l *Libvirt) DomainMemoryStats(Dom Domain, MaxStats uint32, Flags uint32) (
 	}
 
 	var r response
-	r, err = l.request(159, constants.Program, &buf)
+	r, err = l.request(159, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8522,7 +8522,7 @@ func (l *Libvirt) DomainMemoryStats(Dom Domain, MaxStats uint32, Flags uint32) (
 
 // DomainAttachDeviceFlags is the go wrapper for REMOTE_PROC_DOMAIN_ATTACH_DEVICE_FLAGS.
 func (l *Libvirt) DomainAttachDeviceFlags(Dom Domain, XML string, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainAttachDeviceFlagsArgs {
 		Dom: Dom,
@@ -8536,7 +8536,7 @@ func (l *Libvirt) DomainAttachDeviceFlags(Dom Domain, XML string, Flags uint32) 
 	}
 
 
-	_, err = l.request(160, constants.Program, &buf)
+	_, err = l.request(160, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8546,7 +8546,7 @@ func (l *Libvirt) DomainAttachDeviceFlags(Dom Domain, XML string, Flags uint32) 
 
 // DomainDetachDeviceFlags is the go wrapper for REMOTE_PROC_DOMAIN_DETACH_DEVICE_FLAGS.
 func (l *Libvirt) DomainDetachDeviceFlags(Dom Domain, XML string, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainDetachDeviceFlagsArgs {
 		Dom: Dom,
@@ -8560,7 +8560,7 @@ func (l *Libvirt) DomainDetachDeviceFlags(Dom Domain, XML string, Flags uint32) 
 	}
 
 
-	_, err = l.request(161, constants.Program, &buf)
+	_, err = l.request(161, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8570,7 +8570,7 @@ func (l *Libvirt) DomainDetachDeviceFlags(Dom Domain, XML string, Flags uint32) 
 
 // ConnectBaselineCPU is the go wrapper for REMOTE_PROC_CONNECT_BASELINE_CPU.
 func (l *Libvirt) ConnectBaselineCPU(XMLCPUs []string, Flags ConnectBaselineCPUFlags) (rCPU string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectBaselineCPUArgs {
 		XMLCPUs: XMLCPUs,
@@ -8583,7 +8583,7 @@ func (l *Libvirt) ConnectBaselineCPU(XMLCPUs []string, Flags ConnectBaselineCPUF
 	}
 
 	var r response
-	r, err = l.request(162, constants.Program, &buf)
+	r, err = l.request(162, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8602,7 +8602,7 @@ func (l *Libvirt) ConnectBaselineCPU(XMLCPUs []string, Flags ConnectBaselineCPUF
 
 // DomainGetJobInfo is the go wrapper for REMOTE_PROC_DOMAIN_GET_JOB_INFO.
 func (l *Libvirt) DomainGetJobInfo(Dom Domain) (rType int32, rTimeElapsed uint64, rTimeRemaining uint64, rDataTotal uint64, rDataProcessed uint64, rDataRemaining uint64, rMemTotal uint64, rMemProcessed uint64, rMemRemaining uint64, rFileTotal uint64, rFileProcessed uint64, rFileRemaining uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetJobInfoArgs {
 		Dom: Dom,
@@ -8614,7 +8614,7 @@ func (l *Libvirt) DomainGetJobInfo(Dom Domain) (rType int32, rTimeElapsed uint64
 	}
 
 	var r response
-	r, err = l.request(163, constants.Program, &buf)
+	r, err = l.request(163, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8688,7 +8688,7 @@ func (l *Libvirt) DomainGetJobInfo(Dom Domain) (rType int32, rTimeElapsed uint64
 
 // DomainAbortJob is the go wrapper for REMOTE_PROC_DOMAIN_ABORT_JOB.
 func (l *Libvirt) DomainAbortJob(Dom Domain) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainAbortJobArgs {
 		Dom: Dom,
@@ -8700,7 +8700,7 @@ func (l *Libvirt) DomainAbortJob(Dom Domain) (err error) {
 	}
 
 
-	_, err = l.request(164, constants.Program, &buf)
+	_, err = l.request(164, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8710,7 +8710,7 @@ func (l *Libvirt) DomainAbortJob(Dom Domain) (err error) {
 
 // StorageVolWipe is the go wrapper for REMOTE_PROC_STORAGE_VOL_WIPE.
 func (l *Libvirt) StorageVolWipe(Vol StorageVol, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StorageVolWipeArgs {
 		Vol: Vol,
@@ -8723,7 +8723,7 @@ func (l *Libvirt) StorageVolWipe(Vol StorageVol, Flags uint32) (err error) {
 	}
 
 
-	_, err = l.request(165, constants.Program, &buf)
+	_, err = l.request(165, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8733,7 +8733,7 @@ func (l *Libvirt) StorageVolWipe(Vol StorageVol, Flags uint32) (err error) {
 
 // DomainMigrateSetMaxDowntime is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_SET_MAX_DOWNTIME.
 func (l *Libvirt) DomainMigrateSetMaxDowntime(Dom Domain, Downtime uint64, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigrateSetMaxDowntimeArgs {
 		Dom: Dom,
@@ -8747,7 +8747,7 @@ func (l *Libvirt) DomainMigrateSetMaxDowntime(Dom Domain, Downtime uint64, Flags
 	}
 
 
-	_, err = l.request(166, constants.Program, &buf)
+	_, err = l.request(166, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8757,7 +8757,7 @@ func (l *Libvirt) DomainMigrateSetMaxDowntime(Dom Domain, Downtime uint64, Flags
 
 // ConnectDomainEventRegisterAny is the go wrapper for REMOTE_PROC_CONNECT_DOMAIN_EVENT_REGISTER_ANY.
 func (l *Libvirt) ConnectDomainEventRegisterAny(EventID int32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectDomainEventRegisterAnyArgs {
 		EventID: EventID,
@@ -8769,7 +8769,7 @@ func (l *Libvirt) ConnectDomainEventRegisterAny(EventID int32) (err error) {
 	}
 
 
-	_, err = l.request(167, constants.Program, &buf)
+	_, err = l.request(167, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8779,7 +8779,7 @@ func (l *Libvirt) ConnectDomainEventRegisterAny(EventID int32) (err error) {
 
 // ConnectDomainEventDeregisterAny is the go wrapper for REMOTE_PROC_CONNECT_DOMAIN_EVENT_DEREGISTER_ANY.
 func (l *Libvirt) ConnectDomainEventDeregisterAny(EventID int32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectDomainEventDeregisterAnyArgs {
 		EventID: EventID,
@@ -8791,7 +8791,7 @@ func (l *Libvirt) ConnectDomainEventDeregisterAny(EventID int32) (err error) {
 	}
 
 
-	_, err = l.request(168, constants.Program, &buf)
+	_, err = l.request(168, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8801,10 +8801,10 @@ func (l *Libvirt) ConnectDomainEventDeregisterAny(EventID int32) (err error) {
 
 // DomainEventReboot is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_REBOOT.
 func (l *Libvirt) DomainEventReboot() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(169, constants.Program, &buf)
+	_, err = l.request(169, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8814,10 +8814,10 @@ func (l *Libvirt) DomainEventReboot() (err error) {
 
 // DomainEventRtcChange is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_RTC_CHANGE.
 func (l *Libvirt) DomainEventRtcChange() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(170, constants.Program, &buf)
+	_, err = l.request(170, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8827,10 +8827,10 @@ func (l *Libvirt) DomainEventRtcChange() (err error) {
 
 // DomainEventWatchdog is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_WATCHDOG.
 func (l *Libvirt) DomainEventWatchdog() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(171, constants.Program, &buf)
+	_, err = l.request(171, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8840,10 +8840,10 @@ func (l *Libvirt) DomainEventWatchdog() (err error) {
 
 // DomainEventIOError is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_IO_ERROR.
 func (l *Libvirt) DomainEventIOError() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(172, constants.Program, &buf)
+	_, err = l.request(172, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8853,10 +8853,10 @@ func (l *Libvirt) DomainEventIOError() (err error) {
 
 // DomainEventGraphics is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_GRAPHICS.
 func (l *Libvirt) DomainEventGraphics() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(173, constants.Program, &buf)
+	_, err = l.request(173, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8866,7 +8866,7 @@ func (l *Libvirt) DomainEventGraphics() (err error) {
 
 // DomainUpdateDeviceFlags is the go wrapper for REMOTE_PROC_DOMAIN_UPDATE_DEVICE_FLAGS.
 func (l *Libvirt) DomainUpdateDeviceFlags(Dom Domain, XML string, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainUpdateDeviceFlagsArgs {
 		Dom: Dom,
@@ -8880,7 +8880,7 @@ func (l *Libvirt) DomainUpdateDeviceFlags(Dom Domain, XML string, Flags uint32) 
 	}
 
 
-	_, err = l.request(174, constants.Program, &buf)
+	_, err = l.request(174, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8890,7 +8890,7 @@ func (l *Libvirt) DomainUpdateDeviceFlags(Dom Domain, XML string, Flags uint32) 
 
 // NwfilterLookupByName is the go wrapper for REMOTE_PROC_NWFILTER_LOOKUP_BY_NAME.
 func (l *Libvirt) NwfilterLookupByName(Name string) (rOptNwfilter Nwfilter, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NwfilterLookupByNameArgs {
 		Name: Name,
@@ -8902,7 +8902,7 @@ func (l *Libvirt) NwfilterLookupByName(Name string) (rOptNwfilter Nwfilter, err 
 	}
 
 	var r response
-	r, err = l.request(175, constants.Program, &buf)
+	r, err = l.request(175, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8921,7 +8921,7 @@ func (l *Libvirt) NwfilterLookupByName(Name string) (rOptNwfilter Nwfilter, err 
 
 // NwfilterLookupByUUID is the go wrapper for REMOTE_PROC_NWFILTER_LOOKUP_BY_UUID.
 func (l *Libvirt) NwfilterLookupByUUID(UUID UUID) (rOptNwfilter Nwfilter, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NwfilterLookupByUUIDArgs {
 		UUID: UUID,
@@ -8933,7 +8933,7 @@ func (l *Libvirt) NwfilterLookupByUUID(UUID UUID) (rOptNwfilter Nwfilter, err er
 	}
 
 	var r response
-	r, err = l.request(176, constants.Program, &buf)
+	r, err = l.request(176, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8952,7 +8952,7 @@ func (l *Libvirt) NwfilterLookupByUUID(UUID UUID) (rOptNwfilter Nwfilter, err er
 
 // NwfilterGetXMLDesc is the go wrapper for REMOTE_PROC_NWFILTER_GET_XML_DESC.
 func (l *Libvirt) NwfilterGetXMLDesc(OptNwfilter Nwfilter, Flags uint32) (rXML string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NwfilterGetXMLDescArgs {
 		OptNwfilter: OptNwfilter,
@@ -8965,7 +8965,7 @@ func (l *Libvirt) NwfilterGetXMLDesc(OptNwfilter Nwfilter, Flags uint32) (rXML s
 	}
 
 	var r response
-	r, err = l.request(177, constants.Program, &buf)
+	r, err = l.request(177, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -8984,10 +8984,10 @@ func (l *Libvirt) NwfilterGetXMLDesc(OptNwfilter Nwfilter, Flags uint32) (rXML s
 
 // ConnectNumOfNwfilters is the go wrapper for REMOTE_PROC_CONNECT_NUM_OF_NWFILTERS.
 func (l *Libvirt) ConnectNumOfNwfilters() (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	var r response
-	r, err = l.request(178, constants.Program, &buf)
+	r, err = l.request(178, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9006,7 +9006,7 @@ func (l *Libvirt) ConnectNumOfNwfilters() (rNum int32, err error) {
 
 // ConnectListNwfilters is the go wrapper for REMOTE_PROC_CONNECT_LIST_NWFILTERS.
 func (l *Libvirt) ConnectListNwfilters(Maxnames int32) (rNames []string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListNwfiltersArgs {
 		Maxnames: Maxnames,
@@ -9018,7 +9018,7 @@ func (l *Libvirt) ConnectListNwfilters(Maxnames int32) (rNames []string, err err
 	}
 
 	var r response
-	r, err = l.request(179, constants.Program, &buf)
+	r, err = l.request(179, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9037,7 +9037,7 @@ func (l *Libvirt) ConnectListNwfilters(Maxnames int32) (rNames []string, err err
 
 // NwfilterDefineXML is the go wrapper for REMOTE_PROC_NWFILTER_DEFINE_XML.
 func (l *Libvirt) NwfilterDefineXML(XML string) (rOptNwfilter Nwfilter, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NwfilterDefineXMLArgs {
 		XML: XML,
@@ -9049,7 +9049,7 @@ func (l *Libvirt) NwfilterDefineXML(XML string) (rOptNwfilter Nwfilter, err erro
 	}
 
 	var r response
-	r, err = l.request(180, constants.Program, &buf)
+	r, err = l.request(180, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9068,7 +9068,7 @@ func (l *Libvirt) NwfilterDefineXML(XML string) (rOptNwfilter Nwfilter, err erro
 
 // NwfilterUndefine is the go wrapper for REMOTE_PROC_NWFILTER_UNDEFINE.
 func (l *Libvirt) NwfilterUndefine(OptNwfilter Nwfilter) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NwfilterUndefineArgs {
 		OptNwfilter: OptNwfilter,
@@ -9080,7 +9080,7 @@ func (l *Libvirt) NwfilterUndefine(OptNwfilter Nwfilter) (err error) {
 	}
 
 
-	_, err = l.request(181, constants.Program, &buf)
+	_, err = l.request(181, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9090,7 +9090,7 @@ func (l *Libvirt) NwfilterUndefine(OptNwfilter Nwfilter) (err error) {
 
 // DomainManagedSave is the go wrapper for REMOTE_PROC_DOMAIN_MANAGED_SAVE.
 func (l *Libvirt) DomainManagedSave(Dom Domain, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainManagedSaveArgs {
 		Dom: Dom,
@@ -9103,7 +9103,7 @@ func (l *Libvirt) DomainManagedSave(Dom Domain, Flags uint32) (err error) {
 	}
 
 
-	_, err = l.request(182, constants.Program, &buf)
+	_, err = l.request(182, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9113,7 +9113,7 @@ func (l *Libvirt) DomainManagedSave(Dom Domain, Flags uint32) (err error) {
 
 // DomainHasManagedSaveImage is the go wrapper for REMOTE_PROC_DOMAIN_HAS_MANAGED_SAVE_IMAGE.
 func (l *Libvirt) DomainHasManagedSaveImage(Dom Domain, Flags uint32) (rResult int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainHasManagedSaveImageArgs {
 		Dom: Dom,
@@ -9126,7 +9126,7 @@ func (l *Libvirt) DomainHasManagedSaveImage(Dom Domain, Flags uint32) (rResult i
 	}
 
 	var r response
-	r, err = l.request(183, constants.Program, &buf)
+	r, err = l.request(183, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9145,7 +9145,7 @@ func (l *Libvirt) DomainHasManagedSaveImage(Dom Domain, Flags uint32) (rResult i
 
 // DomainManagedSaveRemove is the go wrapper for REMOTE_PROC_DOMAIN_MANAGED_SAVE_REMOVE.
 func (l *Libvirt) DomainManagedSaveRemove(Dom Domain, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainManagedSaveRemoveArgs {
 		Dom: Dom,
@@ -9158,7 +9158,7 @@ func (l *Libvirt) DomainManagedSaveRemove(Dom Domain, Flags uint32) (err error) 
 	}
 
 
-	_, err = l.request(184, constants.Program, &buf)
+	_, err = l.request(184, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9168,7 +9168,7 @@ func (l *Libvirt) DomainManagedSaveRemove(Dom Domain, Flags uint32) (err error) 
 
 // DomainSnapshotCreateXML is the go wrapper for REMOTE_PROC_DOMAIN_SNAPSHOT_CREATE_XML.
 func (l *Libvirt) DomainSnapshotCreateXML(Dom Domain, XMLDesc string, Flags uint32) (rSnap DomainSnapshot, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSnapshotCreateXMLArgs {
 		Dom: Dom,
@@ -9182,7 +9182,7 @@ func (l *Libvirt) DomainSnapshotCreateXML(Dom Domain, XMLDesc string, Flags uint
 	}
 
 	var r response
-	r, err = l.request(185, constants.Program, &buf)
+	r, err = l.request(185, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9201,7 +9201,7 @@ func (l *Libvirt) DomainSnapshotCreateXML(Dom Domain, XMLDesc string, Flags uint
 
 // DomainSnapshotGetXMLDesc is the go wrapper for REMOTE_PROC_DOMAIN_SNAPSHOT_GET_XML_DESC.
 func (l *Libvirt) DomainSnapshotGetXMLDesc(Snap DomainSnapshot, Flags uint32) (rXML string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSnapshotGetXMLDescArgs {
 		Snap: Snap,
@@ -9214,7 +9214,7 @@ func (l *Libvirt) DomainSnapshotGetXMLDesc(Snap DomainSnapshot, Flags uint32) (r
 	}
 
 	var r response
-	r, err = l.request(186, constants.Program, &buf)
+	r, err = l.request(186, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9233,7 +9233,7 @@ func (l *Libvirt) DomainSnapshotGetXMLDesc(Snap DomainSnapshot, Flags uint32) (r
 
 // DomainSnapshotNum is the go wrapper for REMOTE_PROC_DOMAIN_SNAPSHOT_NUM.
 func (l *Libvirt) DomainSnapshotNum(Dom Domain, Flags uint32) (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSnapshotNumArgs {
 		Dom: Dom,
@@ -9246,7 +9246,7 @@ func (l *Libvirt) DomainSnapshotNum(Dom Domain, Flags uint32) (rNum int32, err e
 	}
 
 	var r response
-	r, err = l.request(187, constants.Program, &buf)
+	r, err = l.request(187, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9265,7 +9265,7 @@ func (l *Libvirt) DomainSnapshotNum(Dom Domain, Flags uint32) (rNum int32, err e
 
 // DomainSnapshotListNames is the go wrapper for REMOTE_PROC_DOMAIN_SNAPSHOT_LIST_NAMES.
 func (l *Libvirt) DomainSnapshotListNames(Dom Domain, Maxnames int32, Flags uint32) (rNames []string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSnapshotListNamesArgs {
 		Dom: Dom,
@@ -9279,7 +9279,7 @@ func (l *Libvirt) DomainSnapshotListNames(Dom Domain, Maxnames int32, Flags uint
 	}
 
 	var r response
-	r, err = l.request(188, constants.Program, &buf)
+	r, err = l.request(188, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9298,7 +9298,7 @@ func (l *Libvirt) DomainSnapshotListNames(Dom Domain, Maxnames int32, Flags uint
 
 // DomainSnapshotLookupByName is the go wrapper for REMOTE_PROC_DOMAIN_SNAPSHOT_LOOKUP_BY_NAME.
 func (l *Libvirt) DomainSnapshotLookupByName(Dom Domain, Name string, Flags uint32) (rSnap DomainSnapshot, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSnapshotLookupByNameArgs {
 		Dom: Dom,
@@ -9312,7 +9312,7 @@ func (l *Libvirt) DomainSnapshotLookupByName(Dom Domain, Name string, Flags uint
 	}
 
 	var r response
-	r, err = l.request(189, constants.Program, &buf)
+	r, err = l.request(189, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9331,7 +9331,7 @@ func (l *Libvirt) DomainSnapshotLookupByName(Dom Domain, Name string, Flags uint
 
 // DomainHasCurrentSnapshot is the go wrapper for REMOTE_PROC_DOMAIN_HAS_CURRENT_SNAPSHOT.
 func (l *Libvirt) DomainHasCurrentSnapshot(Dom Domain, Flags uint32) (rResult int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainHasCurrentSnapshotArgs {
 		Dom: Dom,
@@ -9344,7 +9344,7 @@ func (l *Libvirt) DomainHasCurrentSnapshot(Dom Domain, Flags uint32) (rResult in
 	}
 
 	var r response
-	r, err = l.request(190, constants.Program, &buf)
+	r, err = l.request(190, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9363,7 +9363,7 @@ func (l *Libvirt) DomainHasCurrentSnapshot(Dom Domain, Flags uint32) (rResult in
 
 // DomainSnapshotCurrent is the go wrapper for REMOTE_PROC_DOMAIN_SNAPSHOT_CURRENT.
 func (l *Libvirt) DomainSnapshotCurrent(Dom Domain, Flags uint32) (rSnap DomainSnapshot, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSnapshotCurrentArgs {
 		Dom: Dom,
@@ -9376,7 +9376,7 @@ func (l *Libvirt) DomainSnapshotCurrent(Dom Domain, Flags uint32) (rSnap DomainS
 	}
 
 	var r response
-	r, err = l.request(191, constants.Program, &buf)
+	r, err = l.request(191, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9395,7 +9395,7 @@ func (l *Libvirt) DomainSnapshotCurrent(Dom Domain, Flags uint32) (rSnap DomainS
 
 // DomainRevertToSnapshot is the go wrapper for REMOTE_PROC_DOMAIN_REVERT_TO_SNAPSHOT.
 func (l *Libvirt) DomainRevertToSnapshot(Snap DomainSnapshot, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainRevertToSnapshotArgs {
 		Snap: Snap,
@@ -9408,7 +9408,7 @@ func (l *Libvirt) DomainRevertToSnapshot(Snap DomainSnapshot, Flags uint32) (err
 	}
 
 
-	_, err = l.request(192, constants.Program, &buf)
+	_, err = l.request(192, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9418,7 +9418,7 @@ func (l *Libvirt) DomainRevertToSnapshot(Snap DomainSnapshot, Flags uint32) (err
 
 // DomainSnapshotDelete is the go wrapper for REMOTE_PROC_DOMAIN_SNAPSHOT_DELETE.
 func (l *Libvirt) DomainSnapshotDelete(Snap DomainSnapshot, Flags DomainSnapshotDeleteFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSnapshotDeleteArgs {
 		Snap: Snap,
@@ -9431,7 +9431,7 @@ func (l *Libvirt) DomainSnapshotDelete(Snap DomainSnapshot, Flags DomainSnapshot
 	}
 
 
-	_, err = l.request(193, constants.Program, &buf)
+	_, err = l.request(193, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9441,7 +9441,7 @@ func (l *Libvirt) DomainSnapshotDelete(Snap DomainSnapshot, Flags DomainSnapshot
 
 // DomainGetBlockInfo is the go wrapper for REMOTE_PROC_DOMAIN_GET_BLOCK_INFO.
 func (l *Libvirt) DomainGetBlockInfo(Dom Domain, Path string, Flags uint32) (rAllocation uint64, rCapacity uint64, rPhysical uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetBlockInfoArgs {
 		Dom: Dom,
@@ -9455,7 +9455,7 @@ func (l *Libvirt) DomainGetBlockInfo(Dom Domain, Path string, Flags uint32) (rAl
 	}
 
 	var r response
-	r, err = l.request(194, constants.Program, &buf)
+	r, err = l.request(194, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9484,10 +9484,10 @@ func (l *Libvirt) DomainGetBlockInfo(Dom Domain, Path string, Flags uint32) (rAl
 
 // DomainEventIOErrorReason is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_IO_ERROR_REASON.
 func (l *Libvirt) DomainEventIOErrorReason() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(195, constants.Program, &buf)
+	_, err = l.request(195, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9497,7 +9497,7 @@ func (l *Libvirt) DomainEventIOErrorReason() (err error) {
 
 // DomainCreateWithFlags is the go wrapper for REMOTE_PROC_DOMAIN_CREATE_WITH_FLAGS.
 func (l *Libvirt) DomainCreateWithFlags(Dom Domain, Flags uint32) (rDom Domain, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainCreateWithFlagsArgs {
 		Dom: Dom,
@@ -9510,7 +9510,7 @@ func (l *Libvirt) DomainCreateWithFlags(Dom Domain, Flags uint32) (rDom Domain, 
 	}
 
 	var r response
-	r, err = l.request(196, constants.Program, &buf)
+	r, err = l.request(196, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9529,7 +9529,7 @@ func (l *Libvirt) DomainCreateWithFlags(Dom Domain, Flags uint32) (rDom Domain, 
 
 // DomainSetMemoryParameters is the go wrapper for REMOTE_PROC_DOMAIN_SET_MEMORY_PARAMETERS.
 func (l *Libvirt) DomainSetMemoryParameters(Dom Domain, Params []TypedParam, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetMemoryParametersArgs {
 		Dom: Dom,
@@ -9543,7 +9543,7 @@ func (l *Libvirt) DomainSetMemoryParameters(Dom Domain, Params []TypedParam, Fla
 	}
 
 
-	_, err = l.request(197, constants.Program, &buf)
+	_, err = l.request(197, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9553,7 +9553,7 @@ func (l *Libvirt) DomainSetMemoryParameters(Dom Domain, Params []TypedParam, Fla
 
 // DomainGetMemoryParameters is the go wrapper for REMOTE_PROC_DOMAIN_GET_MEMORY_PARAMETERS.
 func (l *Libvirt) DomainGetMemoryParameters(Dom Domain, Nparams int32, Flags uint32) (rParams []TypedParam, rNparams int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetMemoryParametersArgs {
 		Dom: Dom,
@@ -9567,7 +9567,7 @@ func (l *Libvirt) DomainGetMemoryParameters(Dom Domain, Nparams int32, Flags uin
 	}
 
 	var r response
-	r, err = l.request(198, constants.Program, &buf)
+	r, err = l.request(198, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9592,7 +9592,7 @@ func (l *Libvirt) DomainGetMemoryParameters(Dom Domain, Nparams int32, Flags uin
 
 // DomainSetVcpusFlags is the go wrapper for REMOTE_PROC_DOMAIN_SET_VCPUS_FLAGS.
 func (l *Libvirt) DomainSetVcpusFlags(Dom Domain, Nvcpus uint32, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetVcpusFlagsArgs {
 		Dom: Dom,
@@ -9606,7 +9606,7 @@ func (l *Libvirt) DomainSetVcpusFlags(Dom Domain, Nvcpus uint32, Flags uint32) (
 	}
 
 
-	_, err = l.request(199, constants.Program, &buf)
+	_, err = l.request(199, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9616,7 +9616,7 @@ func (l *Libvirt) DomainSetVcpusFlags(Dom Domain, Nvcpus uint32, Flags uint32) (
 
 // DomainGetVcpusFlags is the go wrapper for REMOTE_PROC_DOMAIN_GET_VCPUS_FLAGS.
 func (l *Libvirt) DomainGetVcpusFlags(Dom Domain, Flags uint32) (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetVcpusFlagsArgs {
 		Dom: Dom,
@@ -9629,7 +9629,7 @@ func (l *Libvirt) DomainGetVcpusFlags(Dom Domain, Flags uint32) (rNum int32, err
 	}
 
 	var r response
-	r, err = l.request(200, constants.Program, &buf)
+	r, err = l.request(200, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9648,7 +9648,7 @@ func (l *Libvirt) DomainGetVcpusFlags(Dom Domain, Flags uint32) (rNum int32, err
 
 // DomainOpenConsole is the go wrapper for REMOTE_PROC_DOMAIN_OPEN_CONSOLE.
 func (l *Libvirt) DomainOpenConsole(Dom Domain, DevName OptString, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainOpenConsoleArgs {
 		Dom: Dom,
@@ -9662,7 +9662,7 @@ func (l *Libvirt) DomainOpenConsole(Dom Domain, DevName OptString, Flags uint32)
 	}
 
 
-	_, err = l.request(201, constants.Program, &buf)
+	_, err = l.request(201, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9672,7 +9672,7 @@ func (l *Libvirt) DomainOpenConsole(Dom Domain, DevName OptString, Flags uint32)
 
 // DomainIsUpdated is the go wrapper for REMOTE_PROC_DOMAIN_IS_UPDATED.
 func (l *Libvirt) DomainIsUpdated(Dom Domain) (rUpdated int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainIsUpdatedArgs {
 		Dom: Dom,
@@ -9684,7 +9684,7 @@ func (l *Libvirt) DomainIsUpdated(Dom Domain) (rUpdated int32, err error) {
 	}
 
 	var r response
-	r, err = l.request(202, constants.Program, &buf)
+	r, err = l.request(202, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9703,7 +9703,7 @@ func (l *Libvirt) DomainIsUpdated(Dom Domain) (rUpdated int32, err error) {
 
 // ConnectGetSysinfo is the go wrapper for REMOTE_PROC_CONNECT_GET_SYSINFO.
 func (l *Libvirt) ConnectGetSysinfo(Flags uint32) (rSysinfo string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectGetSysinfoArgs {
 		Flags: Flags,
@@ -9715,7 +9715,7 @@ func (l *Libvirt) ConnectGetSysinfo(Flags uint32) (rSysinfo string, err error) {
 	}
 
 	var r response
-	r, err = l.request(203, constants.Program, &buf)
+	r, err = l.request(203, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9734,7 +9734,7 @@ func (l *Libvirt) ConnectGetSysinfo(Flags uint32) (rSysinfo string, err error) {
 
 // DomainSetMemoryFlags is the go wrapper for REMOTE_PROC_DOMAIN_SET_MEMORY_FLAGS.
 func (l *Libvirt) DomainSetMemoryFlags(Dom Domain, Memory uint64, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetMemoryFlagsArgs {
 		Dom: Dom,
@@ -9748,7 +9748,7 @@ func (l *Libvirt) DomainSetMemoryFlags(Dom Domain, Memory uint64, Flags uint32) 
 	}
 
 
-	_, err = l.request(204, constants.Program, &buf)
+	_, err = l.request(204, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9758,7 +9758,7 @@ func (l *Libvirt) DomainSetMemoryFlags(Dom Domain, Memory uint64, Flags uint32) 
 
 // DomainSetBlkioParameters is the go wrapper for REMOTE_PROC_DOMAIN_SET_BLKIO_PARAMETERS.
 func (l *Libvirt) DomainSetBlkioParameters(Dom Domain, Params []TypedParam, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetBlkioParametersArgs {
 		Dom: Dom,
@@ -9772,7 +9772,7 @@ func (l *Libvirt) DomainSetBlkioParameters(Dom Domain, Params []TypedParam, Flag
 	}
 
 
-	_, err = l.request(205, constants.Program, &buf)
+	_, err = l.request(205, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9782,7 +9782,7 @@ func (l *Libvirt) DomainSetBlkioParameters(Dom Domain, Params []TypedParam, Flag
 
 // DomainGetBlkioParameters is the go wrapper for REMOTE_PROC_DOMAIN_GET_BLKIO_PARAMETERS.
 func (l *Libvirt) DomainGetBlkioParameters(Dom Domain, Nparams int32, Flags uint32) (rParams []TypedParam, rNparams int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetBlkioParametersArgs {
 		Dom: Dom,
@@ -9796,7 +9796,7 @@ func (l *Libvirt) DomainGetBlkioParameters(Dom Domain, Nparams int32, Flags uint
 	}
 
 	var r response
-	r, err = l.request(206, constants.Program, &buf)
+	r, err = l.request(206, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9821,7 +9821,7 @@ func (l *Libvirt) DomainGetBlkioParameters(Dom Domain, Nparams int32, Flags uint
 
 // DomainMigrateSetMaxSpeed is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_SET_MAX_SPEED.
 func (l *Libvirt) DomainMigrateSetMaxSpeed(Dom Domain, Bandwidth uint64, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigrateSetMaxSpeedArgs {
 		Dom: Dom,
@@ -9835,7 +9835,7 @@ func (l *Libvirt) DomainMigrateSetMaxSpeed(Dom Domain, Bandwidth uint64, Flags u
 	}
 
 
-	_, err = l.request(207, constants.Program, &buf)
+	_, err = l.request(207, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9845,7 +9845,7 @@ func (l *Libvirt) DomainMigrateSetMaxSpeed(Dom Domain, Bandwidth uint64, Flags u
 
 // StorageVolUpload is the go wrapper for REMOTE_PROC_STORAGE_VOL_UPLOAD.
 func (l *Libvirt) StorageVolUpload(Vol StorageVol, Offset uint64, Length uint64, Flags StorageVolUploadFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StorageVolUploadArgs {
 		Vol: Vol,
@@ -9860,7 +9860,7 @@ func (l *Libvirt) StorageVolUpload(Vol StorageVol, Offset uint64, Length uint64,
 	}
 
 
-	_, err = l.request(208, constants.Program, &buf)
+	_, err = l.request(208, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9870,7 +9870,7 @@ func (l *Libvirt) StorageVolUpload(Vol StorageVol, Offset uint64, Length uint64,
 
 // StorageVolDownload is the go wrapper for REMOTE_PROC_STORAGE_VOL_DOWNLOAD.
 func (l *Libvirt) StorageVolDownload(Vol StorageVol, Offset uint64, Length uint64, Flags StorageVolDownloadFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StorageVolDownloadArgs {
 		Vol: Vol,
@@ -9885,7 +9885,7 @@ func (l *Libvirt) StorageVolDownload(Vol StorageVol, Offset uint64, Length uint6
 	}
 
 
-	_, err = l.request(209, constants.Program, &buf)
+	_, err = l.request(209, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9895,7 +9895,7 @@ func (l *Libvirt) StorageVolDownload(Vol StorageVol, Offset uint64, Length uint6
 
 // DomainInjectNmi is the go wrapper for REMOTE_PROC_DOMAIN_INJECT_NMI.
 func (l *Libvirt) DomainInjectNmi(Dom Domain, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainInjectNmiArgs {
 		Dom: Dom,
@@ -9908,7 +9908,7 @@ func (l *Libvirt) DomainInjectNmi(Dom Domain, Flags uint32) (err error) {
 	}
 
 
-	_, err = l.request(210, constants.Program, &buf)
+	_, err = l.request(210, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9918,7 +9918,7 @@ func (l *Libvirt) DomainInjectNmi(Dom Domain, Flags uint32) (err error) {
 
 // DomainScreenshot is the go wrapper for REMOTE_PROC_DOMAIN_SCREENSHOT.
 func (l *Libvirt) DomainScreenshot(Dom Domain, Screen uint32, Flags uint32) (rMime OptString, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainScreenshotArgs {
 		Dom: Dom,
@@ -9932,7 +9932,7 @@ func (l *Libvirt) DomainScreenshot(Dom Domain, Screen uint32, Flags uint32) (rMi
 	}
 
 	var r response
-	r, err = l.request(211, constants.Program, &buf)
+	r, err = l.request(211, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9951,7 +9951,7 @@ func (l *Libvirt) DomainScreenshot(Dom Domain, Screen uint32, Flags uint32) (rMi
 
 // DomainGetState is the go wrapper for REMOTE_PROC_DOMAIN_GET_STATE.
 func (l *Libvirt) DomainGetState(Dom Domain, Flags uint32) (rState int32, rReason int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetStateArgs {
 		Dom: Dom,
@@ -9964,7 +9964,7 @@ func (l *Libvirt) DomainGetState(Dom Domain, Flags uint32) (rState int32, rReaso
 	}
 
 	var r response
-	r, err = l.request(212, constants.Program, &buf)
+	r, err = l.request(212, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -9988,7 +9988,7 @@ func (l *Libvirt) DomainGetState(Dom Domain, Flags uint32) (rState int32, rReaso
 
 // DomainMigrateBegin3 is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_BEGIN3.
 func (l *Libvirt) DomainMigrateBegin3(Dom Domain, Xmlin OptString, Flags uint64, Dname OptString, Resource uint64) (rCookieOut []byte, rXML string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigrateBegin3Args {
 		Dom: Dom,
@@ -10004,7 +10004,7 @@ func (l *Libvirt) DomainMigrateBegin3(Dom Domain, Xmlin OptString, Flags uint64,
 	}
 
 	var r response
-	r, err = l.request(213, constants.Program, &buf)
+	r, err = l.request(213, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10028,7 +10028,7 @@ func (l *Libvirt) DomainMigrateBegin3(Dom Domain, Xmlin OptString, Flags uint64,
 
 // DomainMigratePrepare3 is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_PREPARE3.
 func (l *Libvirt) DomainMigratePrepare3(CookieIn []byte, UriIn OptString, Flags uint64, Dname OptString, Resource uint64, DomXML string) (rCookieOut []byte, rUriOut OptString, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigratePrepare3Args {
 		CookieIn: CookieIn,
@@ -10045,7 +10045,7 @@ func (l *Libvirt) DomainMigratePrepare3(CookieIn []byte, UriIn OptString, Flags 
 	}
 
 	var r response
-	r, err = l.request(214, constants.Program, &buf)
+	r, err = l.request(214, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10069,7 +10069,7 @@ func (l *Libvirt) DomainMigratePrepare3(CookieIn []byte, UriIn OptString, Flags 
 
 // DomainMigratePrepareTunnel3 is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_PREPARE_TUNNEL3.
 func (l *Libvirt) DomainMigratePrepareTunnel3(CookieIn []byte, Flags uint64, Dname OptString, Resource uint64, DomXML string) (rCookieOut []byte, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigratePrepareTunnel3Args {
 		CookieIn: CookieIn,
@@ -10085,7 +10085,7 @@ func (l *Libvirt) DomainMigratePrepareTunnel3(CookieIn []byte, Flags uint64, Dna
 	}
 
 	var r response
-	r, err = l.request(215, constants.Program, &buf)
+	r, err = l.request(215, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10104,7 +10104,7 @@ func (l *Libvirt) DomainMigratePrepareTunnel3(CookieIn []byte, Flags uint64, Dna
 
 // DomainMigratePerform3 is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_PERFORM3.
 func (l *Libvirt) DomainMigratePerform3(Dom Domain, Xmlin OptString, CookieIn []byte, Dconnuri OptString, Uri OptString, Flags uint64, Dname OptString, Resource uint64) (rCookieOut []byte, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigratePerform3Args {
 		Dom: Dom,
@@ -10123,7 +10123,7 @@ func (l *Libvirt) DomainMigratePerform3(Dom Domain, Xmlin OptString, CookieIn []
 	}
 
 	var r response
-	r, err = l.request(216, constants.Program, &buf)
+	r, err = l.request(216, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10142,7 +10142,7 @@ func (l *Libvirt) DomainMigratePerform3(Dom Domain, Xmlin OptString, CookieIn []
 
 // DomainMigrateFinish3 is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_FINISH3.
 func (l *Libvirt) DomainMigrateFinish3(Dname string, CookieIn []byte, Dconnuri OptString, Uri OptString, Flags uint64, Cancelled int32) (rDom Domain, rCookieOut []byte, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigrateFinish3Args {
 		Dname: Dname,
@@ -10159,7 +10159,7 @@ func (l *Libvirt) DomainMigrateFinish3(Dname string, CookieIn []byte, Dconnuri O
 	}
 
 	var r response
-	r, err = l.request(217, constants.Program, &buf)
+	r, err = l.request(217, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10183,7 +10183,7 @@ func (l *Libvirt) DomainMigrateFinish3(Dname string, CookieIn []byte, Dconnuri O
 
 // DomainMigrateConfirm3 is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_CONFIRM3.
 func (l *Libvirt) DomainMigrateConfirm3(Dom Domain, CookieIn []byte, Flags uint64, Cancelled int32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigrateConfirm3Args {
 		Dom: Dom,
@@ -10198,7 +10198,7 @@ func (l *Libvirt) DomainMigrateConfirm3(Dom Domain, CookieIn []byte, Flags uint6
 	}
 
 
-	_, err = l.request(218, constants.Program, &buf)
+	_, err = l.request(218, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10208,7 +10208,7 @@ func (l *Libvirt) DomainMigrateConfirm3(Dom Domain, CookieIn []byte, Flags uint6
 
 // DomainSetSchedulerParametersFlags is the go wrapper for REMOTE_PROC_DOMAIN_SET_SCHEDULER_PARAMETERS_FLAGS.
 func (l *Libvirt) DomainSetSchedulerParametersFlags(Dom Domain, Params []TypedParam, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetSchedulerParametersFlagsArgs {
 		Dom: Dom,
@@ -10222,7 +10222,7 @@ func (l *Libvirt) DomainSetSchedulerParametersFlags(Dom Domain, Params []TypedPa
 	}
 
 
-	_, err = l.request(219, constants.Program, &buf)
+	_, err = l.request(219, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10232,7 +10232,7 @@ func (l *Libvirt) DomainSetSchedulerParametersFlags(Dom Domain, Params []TypedPa
 
 // InterfaceChangeBegin is the go wrapper for REMOTE_PROC_INTERFACE_CHANGE_BEGIN.
 func (l *Libvirt) InterfaceChangeBegin(Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := InterfaceChangeBeginArgs {
 		Flags: Flags,
@@ -10244,7 +10244,7 @@ func (l *Libvirt) InterfaceChangeBegin(Flags uint32) (err error) {
 	}
 
 
-	_, err = l.request(220, constants.Program, &buf)
+	_, err = l.request(220, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10254,7 +10254,7 @@ func (l *Libvirt) InterfaceChangeBegin(Flags uint32) (err error) {
 
 // InterfaceChangeCommit is the go wrapper for REMOTE_PROC_INTERFACE_CHANGE_COMMIT.
 func (l *Libvirt) InterfaceChangeCommit(Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := InterfaceChangeCommitArgs {
 		Flags: Flags,
@@ -10266,7 +10266,7 @@ func (l *Libvirt) InterfaceChangeCommit(Flags uint32) (err error) {
 	}
 
 
-	_, err = l.request(221, constants.Program, &buf)
+	_, err = l.request(221, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10276,7 +10276,7 @@ func (l *Libvirt) InterfaceChangeCommit(Flags uint32) (err error) {
 
 // InterfaceChangeRollback is the go wrapper for REMOTE_PROC_INTERFACE_CHANGE_ROLLBACK.
 func (l *Libvirt) InterfaceChangeRollback(Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := InterfaceChangeRollbackArgs {
 		Flags: Flags,
@@ -10288,7 +10288,7 @@ func (l *Libvirt) InterfaceChangeRollback(Flags uint32) (err error) {
 	}
 
 
-	_, err = l.request(222, constants.Program, &buf)
+	_, err = l.request(222, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10298,7 +10298,7 @@ func (l *Libvirt) InterfaceChangeRollback(Flags uint32) (err error) {
 
 // DomainGetSchedulerParametersFlags is the go wrapper for REMOTE_PROC_DOMAIN_GET_SCHEDULER_PARAMETERS_FLAGS.
 func (l *Libvirt) DomainGetSchedulerParametersFlags(Dom Domain, Nparams int32, Flags uint32) (rParams []TypedParam, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetSchedulerParametersFlagsArgs {
 		Dom: Dom,
@@ -10312,7 +10312,7 @@ func (l *Libvirt) DomainGetSchedulerParametersFlags(Dom Domain, Nparams int32, F
 	}
 
 	var r response
-	r, err = l.request(223, constants.Program, &buf)
+	r, err = l.request(223, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10332,10 +10332,10 @@ func (l *Libvirt) DomainGetSchedulerParametersFlags(Dom Domain, Nparams int32, F
 
 // DomainEventControlError is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CONTROL_ERROR.
 func (l *Libvirt) DomainEventControlError() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(224, constants.Program, &buf)
+	_, err = l.request(224, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10345,7 +10345,7 @@ func (l *Libvirt) DomainEventControlError() (err error) {
 
 // DomainPinVcpuFlags is the go wrapper for REMOTE_PROC_DOMAIN_PIN_VCPU_FLAGS.
 func (l *Libvirt) DomainPinVcpuFlags(Dom Domain, Vcpu uint32, Cpumap []byte, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainPinVcpuFlagsArgs {
 		Dom: Dom,
@@ -10360,7 +10360,7 @@ func (l *Libvirt) DomainPinVcpuFlags(Dom Domain, Vcpu uint32, Cpumap []byte, Fla
 	}
 
 
-	_, err = l.request(225, constants.Program, &buf)
+	_, err = l.request(225, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10370,7 +10370,7 @@ func (l *Libvirt) DomainPinVcpuFlags(Dom Domain, Vcpu uint32, Cpumap []byte, Fla
 
 // DomainSendKey is the go wrapper for REMOTE_PROC_DOMAIN_SEND_KEY.
 func (l *Libvirt) DomainSendKey(Dom Domain, Codeset uint32, Holdtime uint32, Keycodes []uint32, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSendKeyArgs {
 		Dom: Dom,
@@ -10386,7 +10386,7 @@ func (l *Libvirt) DomainSendKey(Dom Domain, Codeset uint32, Holdtime uint32, Key
 	}
 
 
-	_, err = l.request(226, constants.Program, &buf)
+	_, err = l.request(226, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10396,7 +10396,7 @@ func (l *Libvirt) DomainSendKey(Dom Domain, Codeset uint32, Holdtime uint32, Key
 
 // NodeGetCPUStats is the go wrapper for REMOTE_PROC_NODE_GET_CPU_STATS.
 func (l *Libvirt) NodeGetCPUStats(CPUNum int32, Nparams int32, Flags uint32) (rParams []NodeGetCPUStats, rNparams int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeGetCPUStatsArgs {
 		CPUNum: CPUNum,
@@ -10410,7 +10410,7 @@ func (l *Libvirt) NodeGetCPUStats(CPUNum int32, Nparams int32, Flags uint32) (rP
 	}
 
 	var r response
-	r, err = l.request(227, constants.Program, &buf)
+	r, err = l.request(227, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10434,7 +10434,7 @@ func (l *Libvirt) NodeGetCPUStats(CPUNum int32, Nparams int32, Flags uint32) (rP
 
 // NodeGetMemoryStats is the go wrapper for REMOTE_PROC_NODE_GET_MEMORY_STATS.
 func (l *Libvirt) NodeGetMemoryStats(Nparams int32, CellNum int32, Flags uint32) (rParams []NodeGetMemoryStats, rNparams int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeGetMemoryStatsArgs {
 		Nparams: Nparams,
@@ -10448,7 +10448,7 @@ func (l *Libvirt) NodeGetMemoryStats(Nparams int32, CellNum int32, Flags uint32)
 	}
 
 	var r response
-	r, err = l.request(228, constants.Program, &buf)
+	r, err = l.request(228, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10472,7 +10472,7 @@ func (l *Libvirt) NodeGetMemoryStats(Nparams int32, CellNum int32, Flags uint32)
 
 // DomainGetControlInfo is the go wrapper for REMOTE_PROC_DOMAIN_GET_CONTROL_INFO.
 func (l *Libvirt) DomainGetControlInfo(Dom Domain, Flags uint32) (rState uint32, rDetails uint32, rStateTime uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetControlInfoArgs {
 		Dom: Dom,
@@ -10485,7 +10485,7 @@ func (l *Libvirt) DomainGetControlInfo(Dom Domain, Flags uint32) (rState uint32,
 	}
 
 	var r response
-	r, err = l.request(229, constants.Program, &buf)
+	r, err = l.request(229, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10514,7 +10514,7 @@ func (l *Libvirt) DomainGetControlInfo(Dom Domain, Flags uint32) (rState uint32,
 
 // DomainGetVcpuPinInfo is the go wrapper for REMOTE_PROC_DOMAIN_GET_VCPU_PIN_INFO.
 func (l *Libvirt) DomainGetVcpuPinInfo(Dom Domain, Ncpumaps int32, Maplen int32, Flags uint32) (rCpumaps []byte, rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetVcpuPinInfoArgs {
 		Dom: Dom,
@@ -10529,7 +10529,7 @@ func (l *Libvirt) DomainGetVcpuPinInfo(Dom Domain, Ncpumaps int32, Maplen int32,
 	}
 
 	var r response
-	r, err = l.request(230, constants.Program, &buf)
+	r, err = l.request(230, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10553,7 +10553,7 @@ func (l *Libvirt) DomainGetVcpuPinInfo(Dom Domain, Ncpumaps int32, Maplen int32,
 
 // DomainUndefineFlags is the go wrapper for REMOTE_PROC_DOMAIN_UNDEFINE_FLAGS.
 func (l *Libvirt) DomainUndefineFlags(Dom Domain, Flags DomainUndefineFlagsValues) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainUndefineFlagsArgs {
 		Dom: Dom,
@@ -10566,7 +10566,7 @@ func (l *Libvirt) DomainUndefineFlags(Dom Domain, Flags DomainUndefineFlagsValue
 	}
 
 
-	_, err = l.request(231, constants.Program, &buf)
+	_, err = l.request(231, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10576,7 +10576,7 @@ func (l *Libvirt) DomainUndefineFlags(Dom Domain, Flags DomainUndefineFlagsValue
 
 // DomainSaveFlags is the go wrapper for REMOTE_PROC_DOMAIN_SAVE_FLAGS.
 func (l *Libvirt) DomainSaveFlags(Dom Domain, To string, Dxml OptString, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSaveFlagsArgs {
 		Dom: Dom,
@@ -10591,7 +10591,7 @@ func (l *Libvirt) DomainSaveFlags(Dom Domain, To string, Dxml OptString, Flags u
 	}
 
 
-	_, err = l.request(232, constants.Program, &buf)
+	_, err = l.request(232, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10601,7 +10601,7 @@ func (l *Libvirt) DomainSaveFlags(Dom Domain, To string, Dxml OptString, Flags u
 
 // DomainRestoreFlags is the go wrapper for REMOTE_PROC_DOMAIN_RESTORE_FLAGS.
 func (l *Libvirt) DomainRestoreFlags(From string, Dxml OptString, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainRestoreFlagsArgs {
 		From: From,
@@ -10615,7 +10615,7 @@ func (l *Libvirt) DomainRestoreFlags(From string, Dxml OptString, Flags uint32) 
 	}
 
 
-	_, err = l.request(233, constants.Program, &buf)
+	_, err = l.request(233, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10625,7 +10625,7 @@ func (l *Libvirt) DomainRestoreFlags(From string, Dxml OptString, Flags uint32) 
 
 // DomainDestroyFlags is the go wrapper for REMOTE_PROC_DOMAIN_DESTROY_FLAGS.
 func (l *Libvirt) DomainDestroyFlags(Dom Domain, Flags DomainDestroyFlagsValues) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainDestroyFlagsArgs {
 		Dom: Dom,
@@ -10638,7 +10638,7 @@ func (l *Libvirt) DomainDestroyFlags(Dom Domain, Flags DomainDestroyFlagsValues)
 	}
 
 
-	_, err = l.request(234, constants.Program, &buf)
+	_, err = l.request(234, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10648,7 +10648,7 @@ func (l *Libvirt) DomainDestroyFlags(Dom Domain, Flags DomainDestroyFlagsValues)
 
 // DomainSaveImageGetXMLDesc is the go wrapper for REMOTE_PROC_DOMAIN_SAVE_IMAGE_GET_XML_DESC.
 func (l *Libvirt) DomainSaveImageGetXMLDesc(File string, Flags uint32) (rXML string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSaveImageGetXMLDescArgs {
 		File: File,
@@ -10661,7 +10661,7 @@ func (l *Libvirt) DomainSaveImageGetXMLDesc(File string, Flags uint32) (rXML str
 	}
 
 	var r response
-	r, err = l.request(235, constants.Program, &buf)
+	r, err = l.request(235, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10680,7 +10680,7 @@ func (l *Libvirt) DomainSaveImageGetXMLDesc(File string, Flags uint32) (rXML str
 
 // DomainSaveImageDefineXML is the go wrapper for REMOTE_PROC_DOMAIN_SAVE_IMAGE_DEFINE_XML.
 func (l *Libvirt) DomainSaveImageDefineXML(File string, Dxml string, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSaveImageDefineXMLArgs {
 		File: File,
@@ -10694,7 +10694,7 @@ func (l *Libvirt) DomainSaveImageDefineXML(File string, Dxml string, Flags uint3
 	}
 
 
-	_, err = l.request(236, constants.Program, &buf)
+	_, err = l.request(236, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10704,7 +10704,7 @@ func (l *Libvirt) DomainSaveImageDefineXML(File string, Dxml string, Flags uint3
 
 // DomainBlockJobAbort is the go wrapper for REMOTE_PROC_DOMAIN_BLOCK_JOB_ABORT.
 func (l *Libvirt) DomainBlockJobAbort(Dom Domain, Path string, Flags DomainBlockJobAbortFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainBlockJobAbortArgs {
 		Dom: Dom,
@@ -10718,7 +10718,7 @@ func (l *Libvirt) DomainBlockJobAbort(Dom Domain, Path string, Flags DomainBlock
 	}
 
 
-	_, err = l.request(237, constants.Program, &buf)
+	_, err = l.request(237, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10728,7 +10728,7 @@ func (l *Libvirt) DomainBlockJobAbort(Dom Domain, Path string, Flags DomainBlock
 
 // DomainGetBlockJobInfo is the go wrapper for REMOTE_PROC_DOMAIN_GET_BLOCK_JOB_INFO.
 func (l *Libvirt) DomainGetBlockJobInfo(Dom Domain, Path string, Flags uint32) (rFound int32, rType int32, rBandwidth uint64, rCur uint64, rEnd uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetBlockJobInfoArgs {
 		Dom: Dom,
@@ -10742,7 +10742,7 @@ func (l *Libvirt) DomainGetBlockJobInfo(Dom Domain, Path string, Flags uint32) (
 	}
 
 	var r response
-	r, err = l.request(238, constants.Program, &buf)
+	r, err = l.request(238, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10781,7 +10781,7 @@ func (l *Libvirt) DomainGetBlockJobInfo(Dom Domain, Path string, Flags uint32) (
 
 // DomainBlockJobSetSpeed is the go wrapper for REMOTE_PROC_DOMAIN_BLOCK_JOB_SET_SPEED.
 func (l *Libvirt) DomainBlockJobSetSpeed(Dom Domain, Path string, Bandwidth uint64, Flags DomainBlockJobSetSpeedFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainBlockJobSetSpeedArgs {
 		Dom: Dom,
@@ -10796,7 +10796,7 @@ func (l *Libvirt) DomainBlockJobSetSpeed(Dom Domain, Path string, Bandwidth uint
 	}
 
 
-	_, err = l.request(239, constants.Program, &buf)
+	_, err = l.request(239, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10806,7 +10806,7 @@ func (l *Libvirt) DomainBlockJobSetSpeed(Dom Domain, Path string, Bandwidth uint
 
 // DomainBlockPull is the go wrapper for REMOTE_PROC_DOMAIN_BLOCK_PULL.
 func (l *Libvirt) DomainBlockPull(Dom Domain, Path string, Bandwidth uint64, Flags DomainBlockPullFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainBlockPullArgs {
 		Dom: Dom,
@@ -10821,7 +10821,7 @@ func (l *Libvirt) DomainBlockPull(Dom Domain, Path string, Bandwidth uint64, Fla
 	}
 
 
-	_, err = l.request(240, constants.Program, &buf)
+	_, err = l.request(240, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10831,10 +10831,10 @@ func (l *Libvirt) DomainBlockPull(Dom Domain, Path string, Bandwidth uint64, Fla
 
 // DomainEventBlockJob is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_BLOCK_JOB.
 func (l *Libvirt) DomainEventBlockJob() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(241, constants.Program, &buf)
+	_, err = l.request(241, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10844,7 +10844,7 @@ func (l *Libvirt) DomainEventBlockJob() (err error) {
 
 // DomainMigrateGetMaxSpeed is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_GET_MAX_SPEED.
 func (l *Libvirt) DomainMigrateGetMaxSpeed(Dom Domain, Flags uint32) (rBandwidth uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigrateGetMaxSpeedArgs {
 		Dom: Dom,
@@ -10857,7 +10857,7 @@ func (l *Libvirt) DomainMigrateGetMaxSpeed(Dom Domain, Flags uint32) (rBandwidth
 	}
 
 	var r response
-	r, err = l.request(242, constants.Program, &buf)
+	r, err = l.request(242, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10876,7 +10876,7 @@ func (l *Libvirt) DomainMigrateGetMaxSpeed(Dom Domain, Flags uint32) (rBandwidth
 
 // DomainBlockStatsFlags is the go wrapper for REMOTE_PROC_DOMAIN_BLOCK_STATS_FLAGS.
 func (l *Libvirt) DomainBlockStatsFlags(Dom Domain, Path string, Nparams int32, Flags uint32) (rParams []TypedParam, rNparams int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainBlockStatsFlagsArgs {
 		Dom: Dom,
@@ -10891,7 +10891,7 @@ func (l *Libvirt) DomainBlockStatsFlags(Dom Domain, Path string, Nparams int32, 
 	}
 
 	var r response
-	r, err = l.request(243, constants.Program, &buf)
+	r, err = l.request(243, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10916,7 +10916,7 @@ func (l *Libvirt) DomainBlockStatsFlags(Dom Domain, Path string, Nparams int32, 
 
 // DomainSnapshotGetParent is the go wrapper for REMOTE_PROC_DOMAIN_SNAPSHOT_GET_PARENT.
 func (l *Libvirt) DomainSnapshotGetParent(Snap DomainSnapshot, Flags uint32) (rSnap DomainSnapshot, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSnapshotGetParentArgs {
 		Snap: Snap,
@@ -10929,7 +10929,7 @@ func (l *Libvirt) DomainSnapshotGetParent(Snap DomainSnapshot, Flags uint32) (rS
 	}
 
 	var r response
-	r, err = l.request(244, constants.Program, &buf)
+	r, err = l.request(244, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10948,7 +10948,7 @@ func (l *Libvirt) DomainSnapshotGetParent(Snap DomainSnapshot, Flags uint32) (rS
 
 // DomainReset is the go wrapper for REMOTE_PROC_DOMAIN_RESET.
 func (l *Libvirt) DomainReset(Dom Domain, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainResetArgs {
 		Dom: Dom,
@@ -10961,7 +10961,7 @@ func (l *Libvirt) DomainReset(Dom Domain, Flags uint32) (err error) {
 	}
 
 
-	_, err = l.request(245, constants.Program, &buf)
+	_, err = l.request(245, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -10971,7 +10971,7 @@ func (l *Libvirt) DomainReset(Dom Domain, Flags uint32) (err error) {
 
 // DomainSnapshotNumChildren is the go wrapper for REMOTE_PROC_DOMAIN_SNAPSHOT_NUM_CHILDREN.
 func (l *Libvirt) DomainSnapshotNumChildren(Snap DomainSnapshot, Flags uint32) (rNum int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSnapshotNumChildrenArgs {
 		Snap: Snap,
@@ -10984,7 +10984,7 @@ func (l *Libvirt) DomainSnapshotNumChildren(Snap DomainSnapshot, Flags uint32) (
 	}
 
 	var r response
-	r, err = l.request(246, constants.Program, &buf)
+	r, err = l.request(246, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11003,7 +11003,7 @@ func (l *Libvirt) DomainSnapshotNumChildren(Snap DomainSnapshot, Flags uint32) (
 
 // DomainSnapshotListChildrenNames is the go wrapper for REMOTE_PROC_DOMAIN_SNAPSHOT_LIST_CHILDREN_NAMES.
 func (l *Libvirt) DomainSnapshotListChildrenNames(Snap DomainSnapshot, Maxnames int32, Flags uint32) (rNames []string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSnapshotListChildrenNamesArgs {
 		Snap: Snap,
@@ -11017,7 +11017,7 @@ func (l *Libvirt) DomainSnapshotListChildrenNames(Snap DomainSnapshot, Maxnames 
 	}
 
 	var r response
-	r, err = l.request(247, constants.Program, &buf)
+	r, err = l.request(247, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11036,10 +11036,10 @@ func (l *Libvirt) DomainSnapshotListChildrenNames(Snap DomainSnapshot, Maxnames 
 
 // DomainEventDiskChange is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_DISK_CHANGE.
 func (l *Libvirt) DomainEventDiskChange() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(248, constants.Program, &buf)
+	_, err = l.request(248, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11049,7 +11049,7 @@ func (l *Libvirt) DomainEventDiskChange() (err error) {
 
 // DomainOpenGraphics is the go wrapper for REMOTE_PROC_DOMAIN_OPEN_GRAPHICS.
 func (l *Libvirt) DomainOpenGraphics(Dom Domain, Idx uint32, Flags DomainOpenGraphicsFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainOpenGraphicsArgs {
 		Dom: Dom,
@@ -11063,7 +11063,7 @@ func (l *Libvirt) DomainOpenGraphics(Dom Domain, Idx uint32, Flags DomainOpenGra
 	}
 
 
-	_, err = l.request(249, constants.Program, &buf)
+	_, err = l.request(249, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11073,7 +11073,7 @@ func (l *Libvirt) DomainOpenGraphics(Dom Domain, Idx uint32, Flags DomainOpenGra
 
 // NodeSuspendForDuration is the go wrapper for REMOTE_PROC_NODE_SUSPEND_FOR_DURATION.
 func (l *Libvirt) NodeSuspendForDuration(Target uint32, Duration uint64, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeSuspendForDurationArgs {
 		Target: Target,
@@ -11087,7 +11087,7 @@ func (l *Libvirt) NodeSuspendForDuration(Target uint32, Duration uint64, Flags u
 	}
 
 
-	_, err = l.request(250, constants.Program, &buf)
+	_, err = l.request(250, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11097,7 +11097,7 @@ func (l *Libvirt) NodeSuspendForDuration(Target uint32, Duration uint64, Flags u
 
 // DomainBlockResize is the go wrapper for REMOTE_PROC_DOMAIN_BLOCK_RESIZE.
 func (l *Libvirt) DomainBlockResize(Dom Domain, Disk string, Size uint64, Flags DomainBlockResizeFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainBlockResizeArgs {
 		Dom: Dom,
@@ -11112,7 +11112,7 @@ func (l *Libvirt) DomainBlockResize(Dom Domain, Disk string, Size uint64, Flags 
 	}
 
 
-	_, err = l.request(251, constants.Program, &buf)
+	_, err = l.request(251, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11122,7 +11122,7 @@ func (l *Libvirt) DomainBlockResize(Dom Domain, Disk string, Size uint64, Flags 
 
 // DomainSetBlockIOTune is the go wrapper for REMOTE_PROC_DOMAIN_SET_BLOCK_IO_TUNE.
 func (l *Libvirt) DomainSetBlockIOTune(Dom Domain, Disk string, Params []TypedParam, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetBlockIOTuneArgs {
 		Dom: Dom,
@@ -11137,7 +11137,7 @@ func (l *Libvirt) DomainSetBlockIOTune(Dom Domain, Disk string, Params []TypedPa
 	}
 
 
-	_, err = l.request(252, constants.Program, &buf)
+	_, err = l.request(252, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11147,7 +11147,7 @@ func (l *Libvirt) DomainSetBlockIOTune(Dom Domain, Disk string, Params []TypedPa
 
 // DomainGetBlockIOTune is the go wrapper for REMOTE_PROC_DOMAIN_GET_BLOCK_IO_TUNE.
 func (l *Libvirt) DomainGetBlockIOTune(Dom Domain, Disk OptString, Nparams int32, Flags uint32) (rParams []TypedParam, rNparams int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetBlockIOTuneArgs {
 		Dom: Dom,
@@ -11162,7 +11162,7 @@ func (l *Libvirt) DomainGetBlockIOTune(Dom Domain, Disk OptString, Nparams int32
 	}
 
 	var r response
-	r, err = l.request(253, constants.Program, &buf)
+	r, err = l.request(253, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11187,7 +11187,7 @@ func (l *Libvirt) DomainGetBlockIOTune(Dom Domain, Disk OptString, Nparams int32
 
 // DomainSetNumaParameters is the go wrapper for REMOTE_PROC_DOMAIN_SET_NUMA_PARAMETERS.
 func (l *Libvirt) DomainSetNumaParameters(Dom Domain, Params []TypedParam, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetNumaParametersArgs {
 		Dom: Dom,
@@ -11201,7 +11201,7 @@ func (l *Libvirt) DomainSetNumaParameters(Dom Domain, Params []TypedParam, Flags
 	}
 
 
-	_, err = l.request(254, constants.Program, &buf)
+	_, err = l.request(254, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11211,7 +11211,7 @@ func (l *Libvirt) DomainSetNumaParameters(Dom Domain, Params []TypedParam, Flags
 
 // DomainGetNumaParameters is the go wrapper for REMOTE_PROC_DOMAIN_GET_NUMA_PARAMETERS.
 func (l *Libvirt) DomainGetNumaParameters(Dom Domain, Nparams int32, Flags uint32) (rParams []TypedParam, rNparams int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetNumaParametersArgs {
 		Dom: Dom,
@@ -11225,7 +11225,7 @@ func (l *Libvirt) DomainGetNumaParameters(Dom Domain, Nparams int32, Flags uint3
 	}
 
 	var r response
-	r, err = l.request(255, constants.Program, &buf)
+	r, err = l.request(255, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11250,7 +11250,7 @@ func (l *Libvirt) DomainGetNumaParameters(Dom Domain, Nparams int32, Flags uint3
 
 // DomainSetInterfaceParameters is the go wrapper for REMOTE_PROC_DOMAIN_SET_INTERFACE_PARAMETERS.
 func (l *Libvirt) DomainSetInterfaceParameters(Dom Domain, Device string, Params []TypedParam, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetInterfaceParametersArgs {
 		Dom: Dom,
@@ -11265,7 +11265,7 @@ func (l *Libvirt) DomainSetInterfaceParameters(Dom Domain, Device string, Params
 	}
 
 
-	_, err = l.request(256, constants.Program, &buf)
+	_, err = l.request(256, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11275,7 +11275,7 @@ func (l *Libvirt) DomainSetInterfaceParameters(Dom Domain, Device string, Params
 
 // DomainGetInterfaceParameters is the go wrapper for REMOTE_PROC_DOMAIN_GET_INTERFACE_PARAMETERS.
 func (l *Libvirt) DomainGetInterfaceParameters(Dom Domain, Device string, Nparams int32, Flags DomainModificationImpact) (rParams []TypedParam, rNparams int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetInterfaceParametersArgs {
 		Dom: Dom,
@@ -11290,7 +11290,7 @@ func (l *Libvirt) DomainGetInterfaceParameters(Dom Domain, Device string, Nparam
 	}
 
 	var r response
-	r, err = l.request(257, constants.Program, &buf)
+	r, err = l.request(257, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11315,7 +11315,7 @@ func (l *Libvirt) DomainGetInterfaceParameters(Dom Domain, Device string, Nparam
 
 // DomainShutdownFlags is the go wrapper for REMOTE_PROC_DOMAIN_SHUTDOWN_FLAGS.
 func (l *Libvirt) DomainShutdownFlags(Dom Domain, Flags DomainShutdownFlagValues) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainShutdownFlagsArgs {
 		Dom: Dom,
@@ -11328,7 +11328,7 @@ func (l *Libvirt) DomainShutdownFlags(Dom Domain, Flags DomainShutdownFlagValues
 	}
 
 
-	_, err = l.request(258, constants.Program, &buf)
+	_, err = l.request(258, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11338,7 +11338,7 @@ func (l *Libvirt) DomainShutdownFlags(Dom Domain, Flags DomainShutdownFlagValues
 
 // StorageVolWipePattern is the go wrapper for REMOTE_PROC_STORAGE_VOL_WIPE_PATTERN.
 func (l *Libvirt) StorageVolWipePattern(Vol StorageVol, Algorithm uint32, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StorageVolWipePatternArgs {
 		Vol: Vol,
@@ -11352,7 +11352,7 @@ func (l *Libvirt) StorageVolWipePattern(Vol StorageVol, Algorithm uint32, Flags 
 	}
 
 
-	_, err = l.request(259, constants.Program, &buf)
+	_, err = l.request(259, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11362,7 +11362,7 @@ func (l *Libvirt) StorageVolWipePattern(Vol StorageVol, Algorithm uint32, Flags 
 
 // StorageVolResize is the go wrapper for REMOTE_PROC_STORAGE_VOL_RESIZE.
 func (l *Libvirt) StorageVolResize(Vol StorageVol, Capacity uint64, Flags StorageVolResizeFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StorageVolResizeArgs {
 		Vol: Vol,
@@ -11376,7 +11376,7 @@ func (l *Libvirt) StorageVolResize(Vol StorageVol, Capacity uint64, Flags Storag
 	}
 
 
-	_, err = l.request(260, constants.Program, &buf)
+	_, err = l.request(260, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11386,7 +11386,7 @@ func (l *Libvirt) StorageVolResize(Vol StorageVol, Capacity uint64, Flags Storag
 
 // DomainPmSuspendForDuration is the go wrapper for REMOTE_PROC_DOMAIN_PM_SUSPEND_FOR_DURATION.
 func (l *Libvirt) DomainPmSuspendForDuration(Dom Domain, Target uint32, Duration uint64, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainPmSuspendForDurationArgs {
 		Dom: Dom,
@@ -11401,7 +11401,7 @@ func (l *Libvirt) DomainPmSuspendForDuration(Dom Domain, Target uint32, Duration
 	}
 
 
-	_, err = l.request(261, constants.Program, &buf)
+	_, err = l.request(261, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11411,7 +11411,7 @@ func (l *Libvirt) DomainPmSuspendForDuration(Dom Domain, Target uint32, Duration
 
 // DomainGetCPUStats is the go wrapper for REMOTE_PROC_DOMAIN_GET_CPU_STATS.
 func (l *Libvirt) DomainGetCPUStats(Dom Domain, Nparams uint32, StartCPU int32, Ncpus uint32, Flags TypedParameterFlags) (rParams []TypedParam, rNparams int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetCPUStatsArgs {
 		Dom: Dom,
@@ -11427,7 +11427,7 @@ func (l *Libvirt) DomainGetCPUStats(Dom Domain, Nparams uint32, StartCPU int32, 
 	}
 
 	var r response
-	r, err = l.request(262, constants.Program, &buf)
+	r, err = l.request(262, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11452,7 +11452,7 @@ func (l *Libvirt) DomainGetCPUStats(Dom Domain, Nparams uint32, StartCPU int32, 
 
 // DomainGetDiskErrors is the go wrapper for REMOTE_PROC_DOMAIN_GET_DISK_ERRORS.
 func (l *Libvirt) DomainGetDiskErrors(Dom Domain, Maxerrors uint32, Flags uint32) (rErrors []DomainDiskError, rNerrors int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetDiskErrorsArgs {
 		Dom: Dom,
@@ -11466,7 +11466,7 @@ func (l *Libvirt) DomainGetDiskErrors(Dom Domain, Maxerrors uint32, Flags uint32
 	}
 
 	var r response
-	r, err = l.request(263, constants.Program, &buf)
+	r, err = l.request(263, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11490,7 +11490,7 @@ func (l *Libvirt) DomainGetDiskErrors(Dom Domain, Maxerrors uint32, Flags uint32
 
 // DomainSetMetadata is the go wrapper for REMOTE_PROC_DOMAIN_SET_METADATA.
 func (l *Libvirt) DomainSetMetadata(Dom Domain, Type int32, Metadata OptString, Key OptString, Uri OptString, Flags DomainModificationImpact) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetMetadataArgs {
 		Dom: Dom,
@@ -11507,7 +11507,7 @@ func (l *Libvirt) DomainSetMetadata(Dom Domain, Type int32, Metadata OptString, 
 	}
 
 
-	_, err = l.request(264, constants.Program, &buf)
+	_, err = l.request(264, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11517,7 +11517,7 @@ func (l *Libvirt) DomainSetMetadata(Dom Domain, Type int32, Metadata OptString, 
 
 // DomainGetMetadata is the go wrapper for REMOTE_PROC_DOMAIN_GET_METADATA.
 func (l *Libvirt) DomainGetMetadata(Dom Domain, Type int32, Uri OptString, Flags DomainModificationImpact) (rMetadata string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetMetadataArgs {
 		Dom: Dom,
@@ -11532,7 +11532,7 @@ func (l *Libvirt) DomainGetMetadata(Dom Domain, Type int32, Uri OptString, Flags
 	}
 
 	var r response
-	r, err = l.request(265, constants.Program, &buf)
+	r, err = l.request(265, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11551,7 +11551,7 @@ func (l *Libvirt) DomainGetMetadata(Dom Domain, Type int32, Uri OptString, Flags
 
 // DomainBlockRebase is the go wrapper for REMOTE_PROC_DOMAIN_BLOCK_REBASE.
 func (l *Libvirt) DomainBlockRebase(Dom Domain, Path string, Base OptString, Bandwidth uint64, Flags DomainBlockRebaseFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainBlockRebaseArgs {
 		Dom: Dom,
@@ -11567,7 +11567,7 @@ func (l *Libvirt) DomainBlockRebase(Dom Domain, Path string, Base OptString, Ban
 	}
 
 
-	_, err = l.request(266, constants.Program, &buf)
+	_, err = l.request(266, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11577,7 +11577,7 @@ func (l *Libvirt) DomainBlockRebase(Dom Domain, Path string, Base OptString, Ban
 
 // DomainPmWakeup is the go wrapper for REMOTE_PROC_DOMAIN_PM_WAKEUP.
 func (l *Libvirt) DomainPmWakeup(Dom Domain, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainPmWakeupArgs {
 		Dom: Dom,
@@ -11590,7 +11590,7 @@ func (l *Libvirt) DomainPmWakeup(Dom Domain, Flags uint32) (err error) {
 	}
 
 
-	_, err = l.request(267, constants.Program, &buf)
+	_, err = l.request(267, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11600,10 +11600,10 @@ func (l *Libvirt) DomainPmWakeup(Dom Domain, Flags uint32) (err error) {
 
 // DomainEventTrayChange is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_TRAY_CHANGE.
 func (l *Libvirt) DomainEventTrayChange() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(268, constants.Program, &buf)
+	_, err = l.request(268, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11613,10 +11613,10 @@ func (l *Libvirt) DomainEventTrayChange() (err error) {
 
 // DomainEventPmwakeup is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_PMWAKEUP.
 func (l *Libvirt) DomainEventPmwakeup() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(269, constants.Program, &buf)
+	_, err = l.request(269, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11626,10 +11626,10 @@ func (l *Libvirt) DomainEventPmwakeup() (err error) {
 
 // DomainEventPmsuspend is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_PMSUSPEND.
 func (l *Libvirt) DomainEventPmsuspend() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(270, constants.Program, &buf)
+	_, err = l.request(270, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11639,7 +11639,7 @@ func (l *Libvirt) DomainEventPmsuspend() (err error) {
 
 // DomainSnapshotIsCurrent is the go wrapper for REMOTE_PROC_DOMAIN_SNAPSHOT_IS_CURRENT.
 func (l *Libvirt) DomainSnapshotIsCurrent(Snap DomainSnapshot, Flags uint32) (rCurrent int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSnapshotIsCurrentArgs {
 		Snap: Snap,
@@ -11652,7 +11652,7 @@ func (l *Libvirt) DomainSnapshotIsCurrent(Snap DomainSnapshot, Flags uint32) (rC
 	}
 
 	var r response
-	r, err = l.request(271, constants.Program, &buf)
+	r, err = l.request(271, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11671,7 +11671,7 @@ func (l *Libvirt) DomainSnapshotIsCurrent(Snap DomainSnapshot, Flags uint32) (rC
 
 // DomainSnapshotHasMetadata is the go wrapper for REMOTE_PROC_DOMAIN_SNAPSHOT_HAS_METADATA.
 func (l *Libvirt) DomainSnapshotHasMetadata(Snap DomainSnapshot, Flags uint32) (rMetadata int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSnapshotHasMetadataArgs {
 		Snap: Snap,
@@ -11684,7 +11684,7 @@ func (l *Libvirt) DomainSnapshotHasMetadata(Snap DomainSnapshot, Flags uint32) (
 	}
 
 	var r response
-	r, err = l.request(272, constants.Program, &buf)
+	r, err = l.request(272, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11703,7 +11703,7 @@ func (l *Libvirt) DomainSnapshotHasMetadata(Snap DomainSnapshot, Flags uint32) (
 
 // ConnectListAllDomains is the go wrapper for REMOTE_PROC_CONNECT_LIST_ALL_DOMAINS.
 func (l *Libvirt) ConnectListAllDomains(NeedResults int32, Flags ConnectListAllDomainsFlags) (rDomains []Domain, rRet uint32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListAllDomainsArgs {
 		NeedResults: NeedResults,
@@ -11716,7 +11716,7 @@ func (l *Libvirt) ConnectListAllDomains(NeedResults int32, Flags ConnectListAllD
 	}
 
 	var r response
-	r, err = l.request(273, constants.Program, &buf)
+	r, err = l.request(273, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11740,7 +11740,7 @@ func (l *Libvirt) ConnectListAllDomains(NeedResults int32, Flags ConnectListAllD
 
 // DomainListAllSnapshots is the go wrapper for REMOTE_PROC_DOMAIN_LIST_ALL_SNAPSHOTS.
 func (l *Libvirt) DomainListAllSnapshots(Dom Domain, NeedResults int32, Flags uint32) (rSnapshots []DomainSnapshot, rRet int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainListAllSnapshotsArgs {
 		Dom: Dom,
@@ -11754,7 +11754,7 @@ func (l *Libvirt) DomainListAllSnapshots(Dom Domain, NeedResults int32, Flags ui
 	}
 
 	var r response
-	r, err = l.request(274, constants.Program, &buf)
+	r, err = l.request(274, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11778,7 +11778,7 @@ func (l *Libvirt) DomainListAllSnapshots(Dom Domain, NeedResults int32, Flags ui
 
 // DomainSnapshotListAllChildren is the go wrapper for REMOTE_PROC_DOMAIN_SNAPSHOT_LIST_ALL_CHILDREN.
 func (l *Libvirt) DomainSnapshotListAllChildren(Snapshot DomainSnapshot, NeedResults int32, Flags uint32) (rSnapshots []DomainSnapshot, rRet int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSnapshotListAllChildrenArgs {
 		Snapshot: Snapshot,
@@ -11792,7 +11792,7 @@ func (l *Libvirt) DomainSnapshotListAllChildren(Snapshot DomainSnapshot, NeedRes
 	}
 
 	var r response
-	r, err = l.request(275, constants.Program, &buf)
+	r, err = l.request(275, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11816,10 +11816,10 @@ func (l *Libvirt) DomainSnapshotListAllChildren(Snapshot DomainSnapshot, NeedRes
 
 // DomainEventBalloonChange is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_BALLOON_CHANGE.
 func (l *Libvirt) DomainEventBalloonChange() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(276, constants.Program, &buf)
+	_, err = l.request(276, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11829,7 +11829,7 @@ func (l *Libvirt) DomainEventBalloonChange() (err error) {
 
 // DomainGetHostname is the go wrapper for REMOTE_PROC_DOMAIN_GET_HOSTNAME.
 func (l *Libvirt) DomainGetHostname(Dom Domain, Flags uint32) (rHostname string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetHostnameArgs {
 		Dom: Dom,
@@ -11842,7 +11842,7 @@ func (l *Libvirt) DomainGetHostname(Dom Domain, Flags uint32) (rHostname string,
 	}
 
 	var r response
-	r, err = l.request(277, constants.Program, &buf)
+	r, err = l.request(277, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11861,7 +11861,7 @@ func (l *Libvirt) DomainGetHostname(Dom Domain, Flags uint32) (rHostname string,
 
 // DomainGetSecurityLabelList is the go wrapper for REMOTE_PROC_DOMAIN_GET_SECURITY_LABEL_LIST.
 func (l *Libvirt) DomainGetSecurityLabelList(Dom Domain) (rLabels []DomainGetSecurityLabelRet, rRet int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetSecurityLabelListArgs {
 		Dom: Dom,
@@ -11873,7 +11873,7 @@ func (l *Libvirt) DomainGetSecurityLabelList(Dom Domain) (rLabels []DomainGetSec
 	}
 
 	var r response
-	r, err = l.request(278, constants.Program, &buf)
+	r, err = l.request(278, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11897,7 +11897,7 @@ func (l *Libvirt) DomainGetSecurityLabelList(Dom Domain) (rLabels []DomainGetSec
 
 // DomainPinEmulator is the go wrapper for REMOTE_PROC_DOMAIN_PIN_EMULATOR.
 func (l *Libvirt) DomainPinEmulator(Dom Domain, Cpumap []byte, Flags DomainModificationImpact) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainPinEmulatorArgs {
 		Dom: Dom,
@@ -11911,7 +11911,7 @@ func (l *Libvirt) DomainPinEmulator(Dom Domain, Cpumap []byte, Flags DomainModif
 	}
 
 
-	_, err = l.request(279, constants.Program, &buf)
+	_, err = l.request(279, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11921,7 +11921,7 @@ func (l *Libvirt) DomainPinEmulator(Dom Domain, Cpumap []byte, Flags DomainModif
 
 // DomainGetEmulatorPinInfo is the go wrapper for REMOTE_PROC_DOMAIN_GET_EMULATOR_PIN_INFO.
 func (l *Libvirt) DomainGetEmulatorPinInfo(Dom Domain, Maplen int32, Flags DomainModificationImpact) (rCpumaps []byte, rRet int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetEmulatorPinInfoArgs {
 		Dom: Dom,
@@ -11935,7 +11935,7 @@ func (l *Libvirt) DomainGetEmulatorPinInfo(Dom Domain, Maplen int32, Flags Domai
 	}
 
 	var r response
-	r, err = l.request(280, constants.Program, &buf)
+	r, err = l.request(280, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11959,7 +11959,7 @@ func (l *Libvirt) DomainGetEmulatorPinInfo(Dom Domain, Maplen int32, Flags Domai
 
 // ConnectListAllStoragePools is the go wrapper for REMOTE_PROC_CONNECT_LIST_ALL_STORAGE_POOLS.
 func (l *Libvirt) ConnectListAllStoragePools(NeedResults int32, Flags ConnectListAllStoragePoolsFlags) (rPools []StoragePool, rRet uint32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListAllStoragePoolsArgs {
 		NeedResults: NeedResults,
@@ -11972,7 +11972,7 @@ func (l *Libvirt) ConnectListAllStoragePools(NeedResults int32, Flags ConnectLis
 	}
 
 	var r response
-	r, err = l.request(281, constants.Program, &buf)
+	r, err = l.request(281, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -11996,7 +11996,7 @@ func (l *Libvirt) ConnectListAllStoragePools(NeedResults int32, Flags ConnectLis
 
 // StoragePoolListAllVolumes is the go wrapper for REMOTE_PROC_STORAGE_POOL_LIST_ALL_VOLUMES.
 func (l *Libvirt) StoragePoolListAllVolumes(Pool StoragePool, NeedResults int32, Flags uint32) (rVols []StorageVol, rRet uint32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StoragePoolListAllVolumesArgs {
 		Pool: Pool,
@@ -12010,7 +12010,7 @@ func (l *Libvirt) StoragePoolListAllVolumes(Pool StoragePool, NeedResults int32,
 	}
 
 	var r response
-	r, err = l.request(282, constants.Program, &buf)
+	r, err = l.request(282, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12034,7 +12034,7 @@ func (l *Libvirt) StoragePoolListAllVolumes(Pool StoragePool, NeedResults int32,
 
 // ConnectListAllNetworks is the go wrapper for REMOTE_PROC_CONNECT_LIST_ALL_NETWORKS.
 func (l *Libvirt) ConnectListAllNetworks(NeedResults int32, Flags ConnectListAllNetworksFlags) (rNets []Network, rRet uint32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListAllNetworksArgs {
 		NeedResults: NeedResults,
@@ -12047,7 +12047,7 @@ func (l *Libvirt) ConnectListAllNetworks(NeedResults int32, Flags ConnectListAll
 	}
 
 	var r response
-	r, err = l.request(283, constants.Program, &buf)
+	r, err = l.request(283, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12071,7 +12071,7 @@ func (l *Libvirt) ConnectListAllNetworks(NeedResults int32, Flags ConnectListAll
 
 // ConnectListAllInterfaces is the go wrapper for REMOTE_PROC_CONNECT_LIST_ALL_INTERFACES.
 func (l *Libvirt) ConnectListAllInterfaces(NeedResults int32, Flags ConnectListAllInterfacesFlags) (rIfaces []Interface, rRet uint32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListAllInterfacesArgs {
 		NeedResults: NeedResults,
@@ -12084,7 +12084,7 @@ func (l *Libvirt) ConnectListAllInterfaces(NeedResults int32, Flags ConnectListA
 	}
 
 	var r response
-	r, err = l.request(284, constants.Program, &buf)
+	r, err = l.request(284, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12108,7 +12108,7 @@ func (l *Libvirt) ConnectListAllInterfaces(NeedResults int32, Flags ConnectListA
 
 // ConnectListAllNodeDevices is the go wrapper for REMOTE_PROC_CONNECT_LIST_ALL_NODE_DEVICES.
 func (l *Libvirt) ConnectListAllNodeDevices(NeedResults int32, Flags uint32) (rDevices []NodeDevice, rRet uint32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListAllNodeDevicesArgs {
 		NeedResults: NeedResults,
@@ -12121,7 +12121,7 @@ func (l *Libvirt) ConnectListAllNodeDevices(NeedResults int32, Flags uint32) (rD
 	}
 
 	var r response
-	r, err = l.request(285, constants.Program, &buf)
+	r, err = l.request(285, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12145,7 +12145,7 @@ func (l *Libvirt) ConnectListAllNodeDevices(NeedResults int32, Flags uint32) (rD
 
 // ConnectListAllNwfilters is the go wrapper for REMOTE_PROC_CONNECT_LIST_ALL_NWFILTERS.
 func (l *Libvirt) ConnectListAllNwfilters(NeedResults int32, Flags uint32) (rFilters []Nwfilter, rRet uint32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListAllNwfiltersArgs {
 		NeedResults: NeedResults,
@@ -12158,7 +12158,7 @@ func (l *Libvirt) ConnectListAllNwfilters(NeedResults int32, Flags uint32) (rFil
 	}
 
 	var r response
-	r, err = l.request(286, constants.Program, &buf)
+	r, err = l.request(286, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12182,7 +12182,7 @@ func (l *Libvirt) ConnectListAllNwfilters(NeedResults int32, Flags uint32) (rFil
 
 // ConnectListAllSecrets is the go wrapper for REMOTE_PROC_CONNECT_LIST_ALL_SECRETS.
 func (l *Libvirt) ConnectListAllSecrets(NeedResults int32, Flags ConnectListAllSecretsFlags) (rSecrets []Secret, rRet uint32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectListAllSecretsArgs {
 		NeedResults: NeedResults,
@@ -12195,7 +12195,7 @@ func (l *Libvirt) ConnectListAllSecrets(NeedResults int32, Flags ConnectListAllS
 	}
 
 	var r response
-	r, err = l.request(287, constants.Program, &buf)
+	r, err = l.request(287, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12219,7 +12219,7 @@ func (l *Libvirt) ConnectListAllSecrets(NeedResults int32, Flags ConnectListAllS
 
 // NodeSetMemoryParameters is the go wrapper for REMOTE_PROC_NODE_SET_MEMORY_PARAMETERS.
 func (l *Libvirt) NodeSetMemoryParameters(Params []TypedParam, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeSetMemoryParametersArgs {
 		Params: Params,
@@ -12232,7 +12232,7 @@ func (l *Libvirt) NodeSetMemoryParameters(Params []TypedParam, Flags uint32) (er
 	}
 
 
-	_, err = l.request(288, constants.Program, &buf)
+	_, err = l.request(288, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12242,7 +12242,7 @@ func (l *Libvirt) NodeSetMemoryParameters(Params []TypedParam, Flags uint32) (er
 
 // NodeGetMemoryParameters is the go wrapper for REMOTE_PROC_NODE_GET_MEMORY_PARAMETERS.
 func (l *Libvirt) NodeGetMemoryParameters(Nparams int32, Flags uint32) (rParams []TypedParam, rNparams int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeGetMemoryParametersArgs {
 		Nparams: Nparams,
@@ -12255,7 +12255,7 @@ func (l *Libvirt) NodeGetMemoryParameters(Nparams int32, Flags uint32) (rParams 
 	}
 
 	var r response
-	r, err = l.request(289, constants.Program, &buf)
+	r, err = l.request(289, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12280,7 +12280,7 @@ func (l *Libvirt) NodeGetMemoryParameters(Nparams int32, Flags uint32) (rParams 
 
 // DomainBlockCommit is the go wrapper for REMOTE_PROC_DOMAIN_BLOCK_COMMIT.
 func (l *Libvirt) DomainBlockCommit(Dom Domain, Disk string, Base OptString, Top OptString, Bandwidth uint64, Flags DomainBlockCommitFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainBlockCommitArgs {
 		Dom: Dom,
@@ -12297,7 +12297,7 @@ func (l *Libvirt) DomainBlockCommit(Dom Domain, Disk string, Base OptString, Top
 	}
 
 
-	_, err = l.request(290, constants.Program, &buf)
+	_, err = l.request(290, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12307,7 +12307,7 @@ func (l *Libvirt) DomainBlockCommit(Dom Domain, Disk string, Base OptString, Top
 
 // NetworkUpdate is the go wrapper for REMOTE_PROC_NETWORK_UPDATE.
 func (l *Libvirt) NetworkUpdate(Net Network, Command uint32, Section uint32, ParentIndex int32, XML string, Flags NetworkUpdateFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NetworkUpdateArgs {
 		Net: Net,
@@ -12324,7 +12324,7 @@ func (l *Libvirt) NetworkUpdate(Net Network, Command uint32, Section uint32, Par
 	}
 
 
-	_, err = l.request(291, constants.Program, &buf)
+	_, err = l.request(291, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12334,10 +12334,10 @@ func (l *Libvirt) NetworkUpdate(Net Network, Command uint32, Section uint32, Par
 
 // DomainEventPmsuspendDisk is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_PMSUSPEND_DISK.
 func (l *Libvirt) DomainEventPmsuspendDisk() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(292, constants.Program, &buf)
+	_, err = l.request(292, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12347,7 +12347,7 @@ func (l *Libvirt) DomainEventPmsuspendDisk() (err error) {
 
 // NodeGetCPUMap is the go wrapper for REMOTE_PROC_NODE_GET_CPU_MAP.
 func (l *Libvirt) NodeGetCPUMap(NeedMap int32, NeedOnline int32, Flags uint32) (rCpumap []byte, rOnline uint32, rRet int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeGetCPUMapArgs {
 		NeedMap: NeedMap,
@@ -12361,7 +12361,7 @@ func (l *Libvirt) NodeGetCPUMap(NeedMap int32, NeedOnline int32, Flags uint32) (
 	}
 
 	var r response
-	r, err = l.request(293, constants.Program, &buf)
+	r, err = l.request(293, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12390,7 +12390,7 @@ func (l *Libvirt) NodeGetCPUMap(NeedMap int32, NeedOnline int32, Flags uint32) (
 
 // DomainFstrim is the go wrapper for REMOTE_PROC_DOMAIN_FSTRIM.
 func (l *Libvirt) DomainFstrim(Dom Domain, MountPoint OptString, Minimum uint64, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainFstrimArgs {
 		Dom: Dom,
@@ -12405,7 +12405,7 @@ func (l *Libvirt) DomainFstrim(Dom Domain, MountPoint OptString, Minimum uint64,
 	}
 
 
-	_, err = l.request(294, constants.Program, &buf)
+	_, err = l.request(294, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12415,7 +12415,7 @@ func (l *Libvirt) DomainFstrim(Dom Domain, MountPoint OptString, Minimum uint64,
 
 // DomainSendProcessSignal is the go wrapper for REMOTE_PROC_DOMAIN_SEND_PROCESS_SIGNAL.
 func (l *Libvirt) DomainSendProcessSignal(Dom Domain, PidValue int64, Signum uint32, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSendProcessSignalArgs {
 		Dom: Dom,
@@ -12430,7 +12430,7 @@ func (l *Libvirt) DomainSendProcessSignal(Dom Domain, PidValue int64, Signum uin
 	}
 
 
-	_, err = l.request(295, constants.Program, &buf)
+	_, err = l.request(295, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12440,7 +12440,7 @@ func (l *Libvirt) DomainSendProcessSignal(Dom Domain, PidValue int64, Signum uin
 
 // DomainOpenChannel is the go wrapper for REMOTE_PROC_DOMAIN_OPEN_CHANNEL.
 func (l *Libvirt) DomainOpenChannel(Dom Domain, Name OptString, Flags DomainChannelFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainOpenChannelArgs {
 		Dom: Dom,
@@ -12454,7 +12454,7 @@ func (l *Libvirt) DomainOpenChannel(Dom Domain, Name OptString, Flags DomainChan
 	}
 
 
-	_, err = l.request(296, constants.Program, &buf)
+	_, err = l.request(296, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12464,7 +12464,7 @@ func (l *Libvirt) DomainOpenChannel(Dom Domain, Name OptString, Flags DomainChan
 
 // NodeDeviceLookupScsiHostByWwn is the go wrapper for REMOTE_PROC_NODE_DEVICE_LOOKUP_SCSI_HOST_BY_WWN.
 func (l *Libvirt) NodeDeviceLookupScsiHostByWwn(Wwnn string, Wwpn string, Flags uint32) (rDev NodeDevice, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeDeviceLookupScsiHostByWwnArgs {
 		Wwnn: Wwnn,
@@ -12478,7 +12478,7 @@ func (l *Libvirt) NodeDeviceLookupScsiHostByWwn(Wwnn string, Wwpn string, Flags 
 	}
 
 	var r response
-	r, err = l.request(297, constants.Program, &buf)
+	r, err = l.request(297, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12497,7 +12497,7 @@ func (l *Libvirt) NodeDeviceLookupScsiHostByWwn(Wwnn string, Wwpn string, Flags 
 
 // DomainGetJobStats is the go wrapper for REMOTE_PROC_DOMAIN_GET_JOB_STATS.
 func (l *Libvirt) DomainGetJobStats(Dom Domain, Flags DomainGetJobStatsFlags) (rType int32, rParams []TypedParam, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetJobStatsArgs {
 		Dom: Dom,
@@ -12510,7 +12510,7 @@ func (l *Libvirt) DomainGetJobStats(Dom Domain, Flags DomainGetJobStatsFlags) (r
 	}
 
 	var r response
-	r, err = l.request(298, constants.Program, &buf)
+	r, err = l.request(298, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12535,7 +12535,7 @@ func (l *Libvirt) DomainGetJobStats(Dom Domain, Flags DomainGetJobStatsFlags) (r
 
 // DomainMigrateGetCompressionCache is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_GET_COMPRESSION_CACHE.
 func (l *Libvirt) DomainMigrateGetCompressionCache(Dom Domain, Flags uint32) (rCacheSize uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigrateGetCompressionCacheArgs {
 		Dom: Dom,
@@ -12548,7 +12548,7 @@ func (l *Libvirt) DomainMigrateGetCompressionCache(Dom Domain, Flags uint32) (rC
 	}
 
 	var r response
-	r, err = l.request(299, constants.Program, &buf)
+	r, err = l.request(299, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12567,7 +12567,7 @@ func (l *Libvirt) DomainMigrateGetCompressionCache(Dom Domain, Flags uint32) (rC
 
 // DomainMigrateSetCompressionCache is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_SET_COMPRESSION_CACHE.
 func (l *Libvirt) DomainMigrateSetCompressionCache(Dom Domain, CacheSize uint64, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigrateSetCompressionCacheArgs {
 		Dom: Dom,
@@ -12581,7 +12581,7 @@ func (l *Libvirt) DomainMigrateSetCompressionCache(Dom Domain, CacheSize uint64,
 	}
 
 
-	_, err = l.request(300, constants.Program, &buf)
+	_, err = l.request(300, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12591,7 +12591,7 @@ func (l *Libvirt) DomainMigrateSetCompressionCache(Dom Domain, CacheSize uint64,
 
 // NodeDeviceDetachFlags is the go wrapper for REMOTE_PROC_NODE_DEVICE_DETACH_FLAGS.
 func (l *Libvirt) NodeDeviceDetachFlags(Name string, DriverName OptString, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeDeviceDetachFlagsArgs {
 		Name: Name,
@@ -12605,7 +12605,7 @@ func (l *Libvirt) NodeDeviceDetachFlags(Name string, DriverName OptString, Flags
 	}
 
 
-	_, err = l.request(301, constants.Program, &buf)
+	_, err = l.request(301, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12615,7 +12615,7 @@ func (l *Libvirt) NodeDeviceDetachFlags(Name string, DriverName OptString, Flags
 
 // DomainMigrateBegin3Params is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_BEGIN3_PARAMS.
 func (l *Libvirt) DomainMigrateBegin3Params(Dom Domain, Params []TypedParam, Flags uint32) (rCookieOut []byte, rXML string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigrateBegin3ParamsArgs {
 		Dom: Dom,
@@ -12629,7 +12629,7 @@ func (l *Libvirt) DomainMigrateBegin3Params(Dom Domain, Params []TypedParam, Fla
 	}
 
 	var r response
-	r, err = l.request(302, constants.Program, &buf)
+	r, err = l.request(302, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12653,7 +12653,7 @@ func (l *Libvirt) DomainMigrateBegin3Params(Dom Domain, Params []TypedParam, Fla
 
 // DomainMigratePrepare3Params is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_PREPARE3_PARAMS.
 func (l *Libvirt) DomainMigratePrepare3Params(Params []TypedParam, CookieIn []byte, Flags uint32) (rCookieOut []byte, rUriOut OptString, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigratePrepare3ParamsArgs {
 		Params: Params,
@@ -12667,7 +12667,7 @@ func (l *Libvirt) DomainMigratePrepare3Params(Params []TypedParam, CookieIn []by
 	}
 
 	var r response
-	r, err = l.request(303, constants.Program, &buf)
+	r, err = l.request(303, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12691,7 +12691,7 @@ func (l *Libvirt) DomainMigratePrepare3Params(Params []TypedParam, CookieIn []by
 
 // DomainMigratePrepareTunnel3Params is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_PREPARE_TUNNEL3_PARAMS.
 func (l *Libvirt) DomainMigratePrepareTunnel3Params(Params []TypedParam, CookieIn []byte, Flags uint32) (rCookieOut []byte, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigratePrepareTunnel3ParamsArgs {
 		Params: Params,
@@ -12705,7 +12705,7 @@ func (l *Libvirt) DomainMigratePrepareTunnel3Params(Params []TypedParam, CookieI
 	}
 
 	var r response
-	r, err = l.request(304, constants.Program, &buf)
+	r, err = l.request(304, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12724,7 +12724,7 @@ func (l *Libvirt) DomainMigratePrepareTunnel3Params(Params []TypedParam, CookieI
 
 // DomainMigratePerform3Params is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_PERFORM3_PARAMS.
 func (l *Libvirt) DomainMigratePerform3Params(Dom Domain, Dconnuri OptString, Params []TypedParam, CookieIn []byte, Flags DomainMigrateFlags) (rCookieOut []byte, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigratePerform3ParamsArgs {
 		Dom: Dom,
@@ -12740,7 +12740,7 @@ func (l *Libvirt) DomainMigratePerform3Params(Dom Domain, Dconnuri OptString, Pa
 	}
 
 	var r response
-	r, err = l.request(305, constants.Program, &buf)
+	r, err = l.request(305, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12759,7 +12759,7 @@ func (l *Libvirt) DomainMigratePerform3Params(Dom Domain, Dconnuri OptString, Pa
 
 // DomainMigrateFinish3Params is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_FINISH3_PARAMS.
 func (l *Libvirt) DomainMigrateFinish3Params(Params []TypedParam, CookieIn []byte, Flags uint32, Cancelled int32) (rDom Domain, rCookieOut []byte, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigrateFinish3ParamsArgs {
 		Params: Params,
@@ -12774,7 +12774,7 @@ func (l *Libvirt) DomainMigrateFinish3Params(Params []TypedParam, CookieIn []byt
 	}
 
 	var r response
-	r, err = l.request(306, constants.Program, &buf)
+	r, err = l.request(306, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12798,7 +12798,7 @@ func (l *Libvirt) DomainMigrateFinish3Params(Params []TypedParam, CookieIn []byt
 
 // DomainMigrateConfirm3Params is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_CONFIRM3_PARAMS.
 func (l *Libvirt) DomainMigrateConfirm3Params(Dom Domain, Params []TypedParam, CookieIn []byte, Flags uint32, Cancelled int32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigrateConfirm3ParamsArgs {
 		Dom: Dom,
@@ -12814,7 +12814,7 @@ func (l *Libvirt) DomainMigrateConfirm3Params(Dom Domain, Params []TypedParam, C
 	}
 
 
-	_, err = l.request(307, constants.Program, &buf)
+	_, err = l.request(307, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12824,7 +12824,7 @@ func (l *Libvirt) DomainMigrateConfirm3Params(Dom Domain, Params []TypedParam, C
 
 // DomainSetMemoryStatsPeriod is the go wrapper for REMOTE_PROC_DOMAIN_SET_MEMORY_STATS_PERIOD.
 func (l *Libvirt) DomainSetMemoryStatsPeriod(Dom Domain, Period int32, Flags DomainMemoryModFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetMemoryStatsPeriodArgs {
 		Dom: Dom,
@@ -12838,7 +12838,7 @@ func (l *Libvirt) DomainSetMemoryStatsPeriod(Dom Domain, Period int32, Flags Dom
 	}
 
 
-	_, err = l.request(308, constants.Program, &buf)
+	_, err = l.request(308, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12848,7 +12848,7 @@ func (l *Libvirt) DomainSetMemoryStatsPeriod(Dom Domain, Period int32, Flags Dom
 
 // DomainCreateXMLWithFiles is the go wrapper for REMOTE_PROC_DOMAIN_CREATE_XML_WITH_FILES.
 func (l *Libvirt) DomainCreateXMLWithFiles(XMLDesc string, Flags DomainCreateFlags) (rDom Domain, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainCreateXMLWithFilesArgs {
 		XMLDesc: XMLDesc,
@@ -12861,7 +12861,7 @@ func (l *Libvirt) DomainCreateXMLWithFiles(XMLDesc string, Flags DomainCreateFla
 	}
 
 	var r response
-	r, err = l.request(309, constants.Program, &buf)
+	r, err = l.request(309, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12880,7 +12880,7 @@ func (l *Libvirt) DomainCreateXMLWithFiles(XMLDesc string, Flags DomainCreateFla
 
 // DomainCreateWithFiles is the go wrapper for REMOTE_PROC_DOMAIN_CREATE_WITH_FILES.
 func (l *Libvirt) DomainCreateWithFiles(Dom Domain, Flags DomainCreateFlags) (rDom Domain, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainCreateWithFilesArgs {
 		Dom: Dom,
@@ -12893,7 +12893,7 @@ func (l *Libvirt) DomainCreateWithFiles(Dom Domain, Flags DomainCreateFlags) (rD
 	}
 
 	var r response
-	r, err = l.request(310, constants.Program, &buf)
+	r, err = l.request(310, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12912,10 +12912,10 @@ func (l *Libvirt) DomainCreateWithFiles(Dom Domain, Flags DomainCreateFlags) (rD
 
 // DomainEventDeviceRemoved is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_DEVICE_REMOVED.
 func (l *Libvirt) DomainEventDeviceRemoved() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(311, constants.Program, &buf)
+	_, err = l.request(311, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12925,7 +12925,7 @@ func (l *Libvirt) DomainEventDeviceRemoved() (err error) {
 
 // ConnectGetCPUModelNames is the go wrapper for REMOTE_PROC_CONNECT_GET_CPU_MODEL_NAMES.
 func (l *Libvirt) ConnectGetCPUModelNames(Arch string, NeedResults int32, Flags uint32) (rModels []string, rRet int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectGetCPUModelNamesArgs {
 		Arch: Arch,
@@ -12939,7 +12939,7 @@ func (l *Libvirt) ConnectGetCPUModelNames(Arch string, NeedResults int32, Flags 
 	}
 
 	var r response
-	r, err = l.request(312, constants.Program, &buf)
+	r, err = l.request(312, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12963,7 +12963,7 @@ func (l *Libvirt) ConnectGetCPUModelNames(Arch string, NeedResults int32, Flags 
 
 // ConnectNetworkEventRegisterAny is the go wrapper for REMOTE_PROC_CONNECT_NETWORK_EVENT_REGISTER_ANY.
 func (l *Libvirt) ConnectNetworkEventRegisterAny(EventID int32, Net OptNetwork) (rCallbackID int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectNetworkEventRegisterAnyArgs {
 		EventID: EventID,
@@ -12976,7 +12976,7 @@ func (l *Libvirt) ConnectNetworkEventRegisterAny(EventID int32, Net OptNetwork) 
 	}
 
 	var r response
-	r, err = l.request(313, constants.Program, &buf)
+	r, err = l.request(313, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -12995,7 +12995,7 @@ func (l *Libvirt) ConnectNetworkEventRegisterAny(EventID int32, Net OptNetwork) 
 
 // ConnectNetworkEventDeregisterAny is the go wrapper for REMOTE_PROC_CONNECT_NETWORK_EVENT_DEREGISTER_ANY.
 func (l *Libvirt) ConnectNetworkEventDeregisterAny(CallbackID int32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectNetworkEventDeregisterAnyArgs {
 		CallbackID: CallbackID,
@@ -13007,7 +13007,7 @@ func (l *Libvirt) ConnectNetworkEventDeregisterAny(CallbackID int32) (err error)
 	}
 
 
-	_, err = l.request(314, constants.Program, &buf)
+	_, err = l.request(314, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13017,10 +13017,10 @@ func (l *Libvirt) ConnectNetworkEventDeregisterAny(CallbackID int32) (err error)
 
 // NetworkEventLifecycle is the go wrapper for REMOTE_PROC_NETWORK_EVENT_LIFECYCLE.
 func (l *Libvirt) NetworkEventLifecycle() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(315, constants.Program, &buf)
+	_, err = l.request(315, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13030,7 +13030,7 @@ func (l *Libvirt) NetworkEventLifecycle() (err error) {
 
 // ConnectDomainEventCallbackRegisterAny is the go wrapper for REMOTE_PROC_CONNECT_DOMAIN_EVENT_CALLBACK_REGISTER_ANY.
 func (l *Libvirt) ConnectDomainEventCallbackRegisterAny(EventID int32, Dom OptDomain) (rCallbackID int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectDomainEventCallbackRegisterAnyArgs {
 		EventID: EventID,
@@ -13043,7 +13043,7 @@ func (l *Libvirt) ConnectDomainEventCallbackRegisterAny(EventID int32, Dom OptDo
 	}
 
 	var r response
-	r, err = l.request(316, constants.Program, &buf)
+	r, err = l.request(316, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13062,7 +13062,7 @@ func (l *Libvirt) ConnectDomainEventCallbackRegisterAny(EventID int32, Dom OptDo
 
 // ConnectDomainEventCallbackDeregisterAny is the go wrapper for REMOTE_PROC_CONNECT_DOMAIN_EVENT_CALLBACK_DEREGISTER_ANY.
 func (l *Libvirt) ConnectDomainEventCallbackDeregisterAny(CallbackID int32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectDomainEventCallbackDeregisterAnyArgs {
 		CallbackID: CallbackID,
@@ -13074,7 +13074,7 @@ func (l *Libvirt) ConnectDomainEventCallbackDeregisterAny(CallbackID int32) (err
 	}
 
 
-	_, err = l.request(317, constants.Program, &buf)
+	_, err = l.request(317, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13084,10 +13084,10 @@ func (l *Libvirt) ConnectDomainEventCallbackDeregisterAny(CallbackID int32) (err
 
 // DomainEventCallbackLifecycle is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_LIFECYCLE.
 func (l *Libvirt) DomainEventCallbackLifecycle() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(318, constants.Program, &buf)
+	_, err = l.request(318, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13097,10 +13097,10 @@ func (l *Libvirt) DomainEventCallbackLifecycle() (err error) {
 
 // DomainEventCallbackReboot is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_REBOOT.
 func (l *Libvirt) DomainEventCallbackReboot() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(319, constants.Program, &buf)
+	_, err = l.request(319, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13110,10 +13110,10 @@ func (l *Libvirt) DomainEventCallbackReboot() (err error) {
 
 // DomainEventCallbackRtcChange is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_RTC_CHANGE.
 func (l *Libvirt) DomainEventCallbackRtcChange() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(320, constants.Program, &buf)
+	_, err = l.request(320, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13123,10 +13123,10 @@ func (l *Libvirt) DomainEventCallbackRtcChange() (err error) {
 
 // DomainEventCallbackWatchdog is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_WATCHDOG.
 func (l *Libvirt) DomainEventCallbackWatchdog() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(321, constants.Program, &buf)
+	_, err = l.request(321, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13136,10 +13136,10 @@ func (l *Libvirt) DomainEventCallbackWatchdog() (err error) {
 
 // DomainEventCallbackIOError is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_IO_ERROR.
 func (l *Libvirt) DomainEventCallbackIOError() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(322, constants.Program, &buf)
+	_, err = l.request(322, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13149,10 +13149,10 @@ func (l *Libvirt) DomainEventCallbackIOError() (err error) {
 
 // DomainEventCallbackGraphics is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_GRAPHICS.
 func (l *Libvirt) DomainEventCallbackGraphics() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(323, constants.Program, &buf)
+	_, err = l.request(323, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13162,10 +13162,10 @@ func (l *Libvirt) DomainEventCallbackGraphics() (err error) {
 
 // DomainEventCallbackIOErrorReason is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_IO_ERROR_REASON.
 func (l *Libvirt) DomainEventCallbackIOErrorReason() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(324, constants.Program, &buf)
+	_, err = l.request(324, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13175,10 +13175,10 @@ func (l *Libvirt) DomainEventCallbackIOErrorReason() (err error) {
 
 // DomainEventCallbackControlError is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_CONTROL_ERROR.
 func (l *Libvirt) DomainEventCallbackControlError() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(325, constants.Program, &buf)
+	_, err = l.request(325, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13188,10 +13188,10 @@ func (l *Libvirt) DomainEventCallbackControlError() (err error) {
 
 // DomainEventCallbackBlockJob is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_BLOCK_JOB.
 func (l *Libvirt) DomainEventCallbackBlockJob() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(326, constants.Program, &buf)
+	_, err = l.request(326, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13201,10 +13201,10 @@ func (l *Libvirt) DomainEventCallbackBlockJob() (err error) {
 
 // DomainEventCallbackDiskChange is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_DISK_CHANGE.
 func (l *Libvirt) DomainEventCallbackDiskChange() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(327, constants.Program, &buf)
+	_, err = l.request(327, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13214,10 +13214,10 @@ func (l *Libvirt) DomainEventCallbackDiskChange() (err error) {
 
 // DomainEventCallbackTrayChange is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_TRAY_CHANGE.
 func (l *Libvirt) DomainEventCallbackTrayChange() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(328, constants.Program, &buf)
+	_, err = l.request(328, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13227,10 +13227,10 @@ func (l *Libvirt) DomainEventCallbackTrayChange() (err error) {
 
 // DomainEventCallbackPmwakeup is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_PMWAKEUP.
 func (l *Libvirt) DomainEventCallbackPmwakeup() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(329, constants.Program, &buf)
+	_, err = l.request(329, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13240,10 +13240,10 @@ func (l *Libvirt) DomainEventCallbackPmwakeup() (err error) {
 
 // DomainEventCallbackPmsuspend is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_PMSUSPEND.
 func (l *Libvirt) DomainEventCallbackPmsuspend() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(330, constants.Program, &buf)
+	_, err = l.request(330, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13253,10 +13253,10 @@ func (l *Libvirt) DomainEventCallbackPmsuspend() (err error) {
 
 // DomainEventCallbackBalloonChange is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_BALLOON_CHANGE.
 func (l *Libvirt) DomainEventCallbackBalloonChange() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(331, constants.Program, &buf)
+	_, err = l.request(331, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13266,10 +13266,10 @@ func (l *Libvirt) DomainEventCallbackBalloonChange() (err error) {
 
 // DomainEventCallbackPmsuspendDisk is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_PMSUSPEND_DISK.
 func (l *Libvirt) DomainEventCallbackPmsuspendDisk() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(332, constants.Program, &buf)
+	_, err = l.request(332, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13279,10 +13279,10 @@ func (l *Libvirt) DomainEventCallbackPmsuspendDisk() (err error) {
 
 // DomainEventCallbackDeviceRemoved is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_DEVICE_REMOVED.
 func (l *Libvirt) DomainEventCallbackDeviceRemoved() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(333, constants.Program, &buf)
+	_, err = l.request(333, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13292,7 +13292,7 @@ func (l *Libvirt) DomainEventCallbackDeviceRemoved() (err error) {
 
 // DomainCoreDumpWithFormat is the go wrapper for REMOTE_PROC_DOMAIN_CORE_DUMP_WITH_FORMAT.
 func (l *Libvirt) DomainCoreDumpWithFormat(Dom Domain, To string, Dumpformat uint32, Flags DomainCoreDumpFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainCoreDumpWithFormatArgs {
 		Dom: Dom,
@@ -13307,7 +13307,7 @@ func (l *Libvirt) DomainCoreDumpWithFormat(Dom Domain, To string, Dumpformat uin
 	}
 
 
-	_, err = l.request(334, constants.Program, &buf)
+	_, err = l.request(334, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13317,7 +13317,7 @@ func (l *Libvirt) DomainCoreDumpWithFormat(Dom Domain, To string, Dumpformat uin
 
 // DomainFsfreeze is the go wrapper for REMOTE_PROC_DOMAIN_FSFREEZE.
 func (l *Libvirt) DomainFsfreeze(Dom Domain, Mountpoints []string, Flags uint32) (rFilesystems int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainFsfreezeArgs {
 		Dom: Dom,
@@ -13331,7 +13331,7 @@ func (l *Libvirt) DomainFsfreeze(Dom Domain, Mountpoints []string, Flags uint32)
 	}
 
 	var r response
-	r, err = l.request(335, constants.Program, &buf)
+	r, err = l.request(335, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13350,7 +13350,7 @@ func (l *Libvirt) DomainFsfreeze(Dom Domain, Mountpoints []string, Flags uint32)
 
 // DomainFsthaw is the go wrapper for REMOTE_PROC_DOMAIN_FSTHAW.
 func (l *Libvirt) DomainFsthaw(Dom Domain, Mountpoints []string, Flags uint32) (rFilesystems int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainFsthawArgs {
 		Dom: Dom,
@@ -13364,7 +13364,7 @@ func (l *Libvirt) DomainFsthaw(Dom Domain, Mountpoints []string, Flags uint32) (
 	}
 
 	var r response
-	r, err = l.request(336, constants.Program, &buf)
+	r, err = l.request(336, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13383,7 +13383,7 @@ func (l *Libvirt) DomainFsthaw(Dom Domain, Mountpoints []string, Flags uint32) (
 
 // DomainGetTime is the go wrapper for REMOTE_PROC_DOMAIN_GET_TIME.
 func (l *Libvirt) DomainGetTime(Dom Domain, Flags uint32) (rSeconds int64, rNseconds uint32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetTimeArgs {
 		Dom: Dom,
@@ -13396,7 +13396,7 @@ func (l *Libvirt) DomainGetTime(Dom Domain, Flags uint32) (rSeconds int64, rNsec
 	}
 
 	var r response
-	r, err = l.request(337, constants.Program, &buf)
+	r, err = l.request(337, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13420,7 +13420,7 @@ func (l *Libvirt) DomainGetTime(Dom Domain, Flags uint32) (rSeconds int64, rNsec
 
 // DomainSetTime is the go wrapper for REMOTE_PROC_DOMAIN_SET_TIME.
 func (l *Libvirt) DomainSetTime(Dom Domain, Seconds int64, Nseconds uint32, Flags DomainSetTimeFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetTimeArgs {
 		Dom: Dom,
@@ -13435,7 +13435,7 @@ func (l *Libvirt) DomainSetTime(Dom Domain, Seconds int64, Nseconds uint32, Flag
 	}
 
 
-	_, err = l.request(338, constants.Program, &buf)
+	_, err = l.request(338, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13445,10 +13445,10 @@ func (l *Libvirt) DomainSetTime(Dom Domain, Seconds int64, Nseconds uint32, Flag
 
 // DomainEventBlockJob2 is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_BLOCK_JOB_2.
 func (l *Libvirt) DomainEventBlockJob2() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(339, constants.Program, &buf)
+	_, err = l.request(339, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13458,7 +13458,7 @@ func (l *Libvirt) DomainEventBlockJob2() (err error) {
 
 // NodeGetFreePages is the go wrapper for REMOTE_PROC_NODE_GET_FREE_PAGES.
 func (l *Libvirt) NodeGetFreePages(Pages []uint32, StartCell int32, CellCount uint32, Flags uint32) (rCounts []uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeGetFreePagesArgs {
 		Pages: Pages,
@@ -13473,7 +13473,7 @@ func (l *Libvirt) NodeGetFreePages(Pages []uint32, StartCell int32, CellCount ui
 	}
 
 	var r response
-	r, err = l.request(340, constants.Program, &buf)
+	r, err = l.request(340, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13492,7 +13492,7 @@ func (l *Libvirt) NodeGetFreePages(Pages []uint32, StartCell int32, CellCount ui
 
 // NetworkGetDhcpLeases is the go wrapper for REMOTE_PROC_NETWORK_GET_DHCP_LEASES.
 func (l *Libvirt) NetworkGetDhcpLeases(Net Network, Mac OptString, NeedResults int32, Flags uint32) (rLeases []NetworkDhcpLease, rRet uint32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NetworkGetDhcpLeasesArgs {
 		Net: Net,
@@ -13507,7 +13507,7 @@ func (l *Libvirt) NetworkGetDhcpLeases(Net Network, Mac OptString, NeedResults i
 	}
 
 	var r response
-	r, err = l.request(341, constants.Program, &buf)
+	r, err = l.request(341, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13531,7 +13531,7 @@ func (l *Libvirt) NetworkGetDhcpLeases(Net Network, Mac OptString, NeedResults i
 
 // ConnectGetDomainCapabilities is the go wrapper for REMOTE_PROC_CONNECT_GET_DOMAIN_CAPABILITIES.
 func (l *Libvirt) ConnectGetDomainCapabilities(Emulatorbin OptString, Arch OptString, Machine OptString, Virttype OptString, Flags uint32) (rCapabilities string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectGetDomainCapabilitiesArgs {
 		Emulatorbin: Emulatorbin,
@@ -13547,7 +13547,7 @@ func (l *Libvirt) ConnectGetDomainCapabilities(Emulatorbin OptString, Arch OptSt
 	}
 
 	var r response
-	r, err = l.request(342, constants.Program, &buf)
+	r, err = l.request(342, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13566,7 +13566,7 @@ func (l *Libvirt) ConnectGetDomainCapabilities(Emulatorbin OptString, Arch OptSt
 
 // DomainOpenGraphicsFd is the go wrapper for REMOTE_PROC_DOMAIN_OPEN_GRAPHICS_FD.
 func (l *Libvirt) DomainOpenGraphicsFd(Dom Domain, Idx uint32, Flags DomainOpenGraphicsFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainOpenGraphicsFdArgs {
 		Dom: Dom,
@@ -13580,7 +13580,7 @@ func (l *Libvirt) DomainOpenGraphicsFd(Dom Domain, Idx uint32, Flags DomainOpenG
 	}
 
 
-	_, err = l.request(343, constants.Program, &buf)
+	_, err = l.request(343, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13590,7 +13590,7 @@ func (l *Libvirt) DomainOpenGraphicsFd(Dom Domain, Idx uint32, Flags DomainOpenG
 
 // ConnectGetAllDomainStats is the go wrapper for REMOTE_PROC_CONNECT_GET_ALL_DOMAIN_STATS.
 func (l *Libvirt) ConnectGetAllDomainStats(Doms []Domain, Stats uint32, Flags ConnectGetAllDomainStatsFlags) (rRetStats []DomainStatsRecord, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectGetAllDomainStatsArgs {
 		Doms: Doms,
@@ -13604,7 +13604,7 @@ func (l *Libvirt) ConnectGetAllDomainStats(Doms []Domain, Stats uint32, Flags Co
 	}
 
 	var r response
-	r, err = l.request(344, constants.Program, &buf)
+	r, err = l.request(344, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13623,7 +13623,7 @@ func (l *Libvirt) ConnectGetAllDomainStats(Doms []Domain, Stats uint32, Flags Co
 
 // DomainBlockCopy is the go wrapper for REMOTE_PROC_DOMAIN_BLOCK_COPY.
 func (l *Libvirt) DomainBlockCopy(Dom Domain, Path string, Destxml string, Params []TypedParam, Flags DomainBlockCopyFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainBlockCopyArgs {
 		Dom: Dom,
@@ -13639,7 +13639,7 @@ func (l *Libvirt) DomainBlockCopy(Dom Domain, Path string, Destxml string, Param
 	}
 
 
-	_, err = l.request(345, constants.Program, &buf)
+	_, err = l.request(345, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13649,10 +13649,10 @@ func (l *Libvirt) DomainBlockCopy(Dom Domain, Path string, Destxml string, Param
 
 // DomainEventCallbackTunable is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_TUNABLE.
 func (l *Libvirt) DomainEventCallbackTunable() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(346, constants.Program, &buf)
+	_, err = l.request(346, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13662,7 +13662,7 @@ func (l *Libvirt) DomainEventCallbackTunable() (err error) {
 
 // NodeAllocPages is the go wrapper for REMOTE_PROC_NODE_ALLOC_PAGES.
 func (l *Libvirt) NodeAllocPages(PageSizes []uint32, PageCounts []uint64, StartCell int32, CellCount uint32, Flags NodeAllocPagesFlags) (rRet int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := NodeAllocPagesArgs {
 		PageSizes: PageSizes,
@@ -13678,7 +13678,7 @@ func (l *Libvirt) NodeAllocPages(PageSizes []uint32, PageCounts []uint64, StartC
 	}
 
 	var r response
-	r, err = l.request(347, constants.Program, &buf)
+	r, err = l.request(347, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13697,10 +13697,10 @@ func (l *Libvirt) NodeAllocPages(PageSizes []uint32, PageCounts []uint64, StartC
 
 // DomainEventCallbackAgentLifecycle is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_AGENT_LIFECYCLE.
 func (l *Libvirt) DomainEventCallbackAgentLifecycle() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(348, constants.Program, &buf)
+	_, err = l.request(348, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13710,7 +13710,7 @@ func (l *Libvirt) DomainEventCallbackAgentLifecycle() (err error) {
 
 // DomainGetFsinfo is the go wrapper for REMOTE_PROC_DOMAIN_GET_FSINFO.
 func (l *Libvirt) DomainGetFsinfo(Dom Domain, Flags uint32) (rInfo []DomainFsinfo, rRet uint32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetFsinfoArgs {
 		Dom: Dom,
@@ -13723,7 +13723,7 @@ func (l *Libvirt) DomainGetFsinfo(Dom Domain, Flags uint32) (rInfo []DomainFsinf
 	}
 
 	var r response
-	r, err = l.request(349, constants.Program, &buf)
+	r, err = l.request(349, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13747,7 +13747,7 @@ func (l *Libvirt) DomainGetFsinfo(Dom Domain, Flags uint32) (rInfo []DomainFsinf
 
 // DomainDefineXMLFlags is the go wrapper for REMOTE_PROC_DOMAIN_DEFINE_XML_FLAGS.
 func (l *Libvirt) DomainDefineXMLFlags(XML string, Flags DomainDefineFlags) (rDom Domain, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainDefineXMLFlagsArgs {
 		XML: XML,
@@ -13760,7 +13760,7 @@ func (l *Libvirt) DomainDefineXMLFlags(XML string, Flags DomainDefineFlags) (rDo
 	}
 
 	var r response
-	r, err = l.request(350, constants.Program, &buf)
+	r, err = l.request(350, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13779,7 +13779,7 @@ func (l *Libvirt) DomainDefineXMLFlags(XML string, Flags DomainDefineFlags) (rDo
 
 // DomainGetIothreadInfo is the go wrapper for REMOTE_PROC_DOMAIN_GET_IOTHREAD_INFO.
 func (l *Libvirt) DomainGetIothreadInfo(Dom Domain, Flags DomainModificationImpact) (rInfo []DomainIothreadInfo, rRet uint32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetIothreadInfoArgs {
 		Dom: Dom,
@@ -13792,7 +13792,7 @@ func (l *Libvirt) DomainGetIothreadInfo(Dom Domain, Flags DomainModificationImpa
 	}
 
 	var r response
-	r, err = l.request(351, constants.Program, &buf)
+	r, err = l.request(351, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13816,7 +13816,7 @@ func (l *Libvirt) DomainGetIothreadInfo(Dom Domain, Flags DomainModificationImpa
 
 // DomainPinIothread is the go wrapper for REMOTE_PROC_DOMAIN_PIN_IOTHREAD.
 func (l *Libvirt) DomainPinIothread(Dom Domain, IothreadsID uint32, Cpumap []byte, Flags DomainModificationImpact) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainPinIothreadArgs {
 		Dom: Dom,
@@ -13831,7 +13831,7 @@ func (l *Libvirt) DomainPinIothread(Dom Domain, IothreadsID uint32, Cpumap []byt
 	}
 
 
-	_, err = l.request(352, constants.Program, &buf)
+	_, err = l.request(352, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13841,7 +13841,7 @@ func (l *Libvirt) DomainPinIothread(Dom Domain, IothreadsID uint32, Cpumap []byt
 
 // DomainInterfaceAddresses is the go wrapper for REMOTE_PROC_DOMAIN_INTERFACE_ADDRESSES.
 func (l *Libvirt) DomainInterfaceAddresses(Dom Domain, Source uint32, Flags uint32) (rIfaces []DomainInterface, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainInterfaceAddressesArgs {
 		Dom: Dom,
@@ -13855,7 +13855,7 @@ func (l *Libvirt) DomainInterfaceAddresses(Dom Domain, Source uint32, Flags uint
 	}
 
 	var r response
-	r, err = l.request(353, constants.Program, &buf)
+	r, err = l.request(353, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13874,10 +13874,10 @@ func (l *Libvirt) DomainInterfaceAddresses(Dom Domain, Source uint32, Flags uint
 
 // DomainEventCallbackDeviceAdded is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_DEVICE_ADDED.
 func (l *Libvirt) DomainEventCallbackDeviceAdded() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(354, constants.Program, &buf)
+	_, err = l.request(354, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13887,7 +13887,7 @@ func (l *Libvirt) DomainEventCallbackDeviceAdded() (err error) {
 
 // DomainAddIothread is the go wrapper for REMOTE_PROC_DOMAIN_ADD_IOTHREAD.
 func (l *Libvirt) DomainAddIothread(Dom Domain, IothreadID uint32, Flags DomainModificationImpact) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainAddIothreadArgs {
 		Dom: Dom,
@@ -13901,7 +13901,7 @@ func (l *Libvirt) DomainAddIothread(Dom Domain, IothreadID uint32, Flags DomainM
 	}
 
 
-	_, err = l.request(355, constants.Program, &buf)
+	_, err = l.request(355, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13911,7 +13911,7 @@ func (l *Libvirt) DomainAddIothread(Dom Domain, IothreadID uint32, Flags DomainM
 
 // DomainDelIothread is the go wrapper for REMOTE_PROC_DOMAIN_DEL_IOTHREAD.
 func (l *Libvirt) DomainDelIothread(Dom Domain, IothreadID uint32, Flags DomainModificationImpact) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainDelIothreadArgs {
 		Dom: Dom,
@@ -13925,7 +13925,7 @@ func (l *Libvirt) DomainDelIothread(Dom Domain, IothreadID uint32, Flags DomainM
 	}
 
 
-	_, err = l.request(356, constants.Program, &buf)
+	_, err = l.request(356, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13935,7 +13935,7 @@ func (l *Libvirt) DomainDelIothread(Dom Domain, IothreadID uint32, Flags DomainM
 
 // DomainSetUserPassword is the go wrapper for REMOTE_PROC_DOMAIN_SET_USER_PASSWORD.
 func (l *Libvirt) DomainSetUserPassword(Dom Domain, User OptString, Password OptString, Flags DomainSetUserPasswordFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetUserPasswordArgs {
 		Dom: Dom,
@@ -13950,7 +13950,7 @@ func (l *Libvirt) DomainSetUserPassword(Dom Domain, User OptString, Password Opt
 	}
 
 
-	_, err = l.request(357, constants.Program, &buf)
+	_, err = l.request(357, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13960,7 +13960,7 @@ func (l *Libvirt) DomainSetUserPassword(Dom Domain, User OptString, Password Opt
 
 // DomainRename is the go wrapper for REMOTE_PROC_DOMAIN_RENAME.
 func (l *Libvirt) DomainRename(Dom Domain, NewName OptString, Flags uint32) (rRetcode int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainRenameArgs {
 		Dom: Dom,
@@ -13974,7 +13974,7 @@ func (l *Libvirt) DomainRename(Dom Domain, NewName OptString, Flags uint32) (rRe
 	}
 
 	var r response
-	r, err = l.request(358, constants.Program, &buf)
+	r, err = l.request(358, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -13993,10 +13993,10 @@ func (l *Libvirt) DomainRename(Dom Domain, NewName OptString, Flags uint32) (rRe
 
 // DomainEventCallbackMigrationIteration is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_MIGRATION_ITERATION.
 func (l *Libvirt) DomainEventCallbackMigrationIteration() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(359, constants.Program, &buf)
+	_, err = l.request(359, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14006,10 +14006,10 @@ func (l *Libvirt) DomainEventCallbackMigrationIteration() (err error) {
 
 // ConnectRegisterCloseCallback is the go wrapper for REMOTE_PROC_CONNECT_REGISTER_CLOSE_CALLBACK.
 func (l *Libvirt) ConnectRegisterCloseCallback() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(360, constants.Program, &buf)
+	_, err = l.request(360, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14019,10 +14019,10 @@ func (l *Libvirt) ConnectRegisterCloseCallback() (err error) {
 
 // ConnectUnregisterCloseCallback is the go wrapper for REMOTE_PROC_CONNECT_UNREGISTER_CLOSE_CALLBACK.
 func (l *Libvirt) ConnectUnregisterCloseCallback() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(361, constants.Program, &buf)
+	_, err = l.request(361, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14032,10 +14032,10 @@ func (l *Libvirt) ConnectUnregisterCloseCallback() (err error) {
 
 // ConnectEventConnectionClosed is the go wrapper for REMOTE_PROC_CONNECT_EVENT_CONNECTION_CLOSED.
 func (l *Libvirt) ConnectEventConnectionClosed() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(362, constants.Program, &buf)
+	_, err = l.request(362, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14045,10 +14045,10 @@ func (l *Libvirt) ConnectEventConnectionClosed() (err error) {
 
 // DomainEventCallbackJobCompleted is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_JOB_COMPLETED.
 func (l *Libvirt) DomainEventCallbackJobCompleted() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(363, constants.Program, &buf)
+	_, err = l.request(363, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14058,7 +14058,7 @@ func (l *Libvirt) DomainEventCallbackJobCompleted() (err error) {
 
 // DomainMigrateStartPostCopy is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_START_POST_COPY.
 func (l *Libvirt) DomainMigrateStartPostCopy(Dom Domain, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigrateStartPostCopyArgs {
 		Dom: Dom,
@@ -14071,7 +14071,7 @@ func (l *Libvirt) DomainMigrateStartPostCopy(Dom Domain, Flags uint32) (err erro
 	}
 
 
-	_, err = l.request(364, constants.Program, &buf)
+	_, err = l.request(364, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14081,7 +14081,7 @@ func (l *Libvirt) DomainMigrateStartPostCopy(Dom Domain, Flags uint32) (err erro
 
 // DomainGetPerfEvents is the go wrapper for REMOTE_PROC_DOMAIN_GET_PERF_EVENTS.
 func (l *Libvirt) DomainGetPerfEvents(Dom Domain, Flags DomainModificationImpact) (rParams []TypedParam, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetPerfEventsArgs {
 		Dom: Dom,
@@ -14094,7 +14094,7 @@ func (l *Libvirt) DomainGetPerfEvents(Dom Domain, Flags DomainModificationImpact
 	}
 
 	var r response
-	r, err = l.request(365, constants.Program, &buf)
+	r, err = l.request(365, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14114,7 +14114,7 @@ func (l *Libvirt) DomainGetPerfEvents(Dom Domain, Flags DomainModificationImpact
 
 // DomainSetPerfEvents is the go wrapper for REMOTE_PROC_DOMAIN_SET_PERF_EVENTS.
 func (l *Libvirt) DomainSetPerfEvents(Dom Domain, Params []TypedParam, Flags DomainModificationImpact) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetPerfEventsArgs {
 		Dom: Dom,
@@ -14128,7 +14128,7 @@ func (l *Libvirt) DomainSetPerfEvents(Dom Domain, Params []TypedParam, Flags Dom
 	}
 
 
-	_, err = l.request(366, constants.Program, &buf)
+	_, err = l.request(366, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14138,10 +14138,10 @@ func (l *Libvirt) DomainSetPerfEvents(Dom Domain, Params []TypedParam, Flags Dom
 
 // DomainEventCallbackDeviceRemovalFailed is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_DEVICE_REMOVAL_FAILED.
 func (l *Libvirt) DomainEventCallbackDeviceRemovalFailed() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(367, constants.Program, &buf)
+	_, err = l.request(367, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14151,7 +14151,7 @@ func (l *Libvirt) DomainEventCallbackDeviceRemovalFailed() (err error) {
 
 // ConnectStoragePoolEventRegisterAny is the go wrapper for REMOTE_PROC_CONNECT_STORAGE_POOL_EVENT_REGISTER_ANY.
 func (l *Libvirt) ConnectStoragePoolEventRegisterAny(EventID int32, Pool OptStoragePool) (rCallbackID int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectStoragePoolEventRegisterAnyArgs {
 		EventID: EventID,
@@ -14164,7 +14164,7 @@ func (l *Libvirt) ConnectStoragePoolEventRegisterAny(EventID int32, Pool OptStor
 	}
 
 	var r response
-	r, err = l.request(368, constants.Program, &buf)
+	r, err = l.request(368, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14183,7 +14183,7 @@ func (l *Libvirt) ConnectStoragePoolEventRegisterAny(EventID int32, Pool OptStor
 
 // ConnectStoragePoolEventDeregisterAny is the go wrapper for REMOTE_PROC_CONNECT_STORAGE_POOL_EVENT_DEREGISTER_ANY.
 func (l *Libvirt) ConnectStoragePoolEventDeregisterAny(CallbackID int32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectStoragePoolEventDeregisterAnyArgs {
 		CallbackID: CallbackID,
@@ -14195,7 +14195,7 @@ func (l *Libvirt) ConnectStoragePoolEventDeregisterAny(CallbackID int32) (err er
 	}
 
 
-	_, err = l.request(369, constants.Program, &buf)
+	_, err = l.request(369, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14205,10 +14205,10 @@ func (l *Libvirt) ConnectStoragePoolEventDeregisterAny(CallbackID int32) (err er
 
 // StoragePoolEventLifecycle is the go wrapper for REMOTE_PROC_STORAGE_POOL_EVENT_LIFECYCLE.
 func (l *Libvirt) StoragePoolEventLifecycle() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(370, constants.Program, &buf)
+	_, err = l.request(370, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14218,7 +14218,7 @@ func (l *Libvirt) StoragePoolEventLifecycle() (err error) {
 
 // DomainGetGuestVcpus is the go wrapper for REMOTE_PROC_DOMAIN_GET_GUEST_VCPUS.
 func (l *Libvirt) DomainGetGuestVcpus(Dom Domain, Flags uint32) (rParams []TypedParam, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainGetGuestVcpusArgs {
 		Dom: Dom,
@@ -14231,7 +14231,7 @@ func (l *Libvirt) DomainGetGuestVcpus(Dom Domain, Flags uint32) (rParams []Typed
 	}
 
 	var r response
-	r, err = l.request(371, constants.Program, &buf)
+	r, err = l.request(371, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14251,7 +14251,7 @@ func (l *Libvirt) DomainGetGuestVcpus(Dom Domain, Flags uint32) (rParams []Typed
 
 // DomainSetGuestVcpus is the go wrapper for REMOTE_PROC_DOMAIN_SET_GUEST_VCPUS.
 func (l *Libvirt) DomainSetGuestVcpus(Dom Domain, Cpumap string, State int32, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetGuestVcpusArgs {
 		Dom: Dom,
@@ -14266,7 +14266,7 @@ func (l *Libvirt) DomainSetGuestVcpus(Dom Domain, Cpumap string, State int32, Fl
 	}
 
 
-	_, err = l.request(372, constants.Program, &buf)
+	_, err = l.request(372, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14276,10 +14276,10 @@ func (l *Libvirt) DomainSetGuestVcpus(Dom Domain, Cpumap string, State int32, Fl
 
 // StoragePoolEventRefresh is the go wrapper for REMOTE_PROC_STORAGE_POOL_EVENT_REFRESH.
 func (l *Libvirt) StoragePoolEventRefresh() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(373, constants.Program, &buf)
+	_, err = l.request(373, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14289,7 +14289,7 @@ func (l *Libvirt) StoragePoolEventRefresh() (err error) {
 
 // ConnectNodeDeviceEventRegisterAny is the go wrapper for REMOTE_PROC_CONNECT_NODE_DEVICE_EVENT_REGISTER_ANY.
 func (l *Libvirt) ConnectNodeDeviceEventRegisterAny(EventID int32, Dev OptNodeDevice) (rCallbackID int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectNodeDeviceEventRegisterAnyArgs {
 		EventID: EventID,
@@ -14302,7 +14302,7 @@ func (l *Libvirt) ConnectNodeDeviceEventRegisterAny(EventID int32, Dev OptNodeDe
 	}
 
 	var r response
-	r, err = l.request(374, constants.Program, &buf)
+	r, err = l.request(374, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14321,7 +14321,7 @@ func (l *Libvirt) ConnectNodeDeviceEventRegisterAny(EventID int32, Dev OptNodeDe
 
 // ConnectNodeDeviceEventDeregisterAny is the go wrapper for REMOTE_PROC_CONNECT_NODE_DEVICE_EVENT_DEREGISTER_ANY.
 func (l *Libvirt) ConnectNodeDeviceEventDeregisterAny(CallbackID int32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectNodeDeviceEventDeregisterAnyArgs {
 		CallbackID: CallbackID,
@@ -14333,7 +14333,7 @@ func (l *Libvirt) ConnectNodeDeviceEventDeregisterAny(CallbackID int32) (err err
 	}
 
 
-	_, err = l.request(375, constants.Program, &buf)
+	_, err = l.request(375, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14343,10 +14343,10 @@ func (l *Libvirt) ConnectNodeDeviceEventDeregisterAny(CallbackID int32) (err err
 
 // NodeDeviceEventLifecycle is the go wrapper for REMOTE_PROC_NODE_DEVICE_EVENT_LIFECYCLE.
 func (l *Libvirt) NodeDeviceEventLifecycle() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(376, constants.Program, &buf)
+	_, err = l.request(376, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14356,10 +14356,10 @@ func (l *Libvirt) NodeDeviceEventLifecycle() (err error) {
 
 // NodeDeviceEventUpdate is the go wrapper for REMOTE_PROC_NODE_DEVICE_EVENT_UPDATE.
 func (l *Libvirt) NodeDeviceEventUpdate() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(377, constants.Program, &buf)
+	_, err = l.request(377, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14369,7 +14369,7 @@ func (l *Libvirt) NodeDeviceEventUpdate() (err error) {
 
 // StorageVolGetInfoFlags is the go wrapper for REMOTE_PROC_STORAGE_VOL_GET_INFO_FLAGS.
 func (l *Libvirt) StorageVolGetInfoFlags(Vol StorageVol, Flags uint32) (rType int8, rCapacity uint64, rAllocation uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := StorageVolGetInfoFlagsArgs {
 		Vol: Vol,
@@ -14382,7 +14382,7 @@ func (l *Libvirt) StorageVolGetInfoFlags(Vol StorageVol, Flags uint32) (rType in
 	}
 
 	var r response
-	r, err = l.request(378, constants.Program, &buf)
+	r, err = l.request(378, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14411,10 +14411,10 @@ func (l *Libvirt) StorageVolGetInfoFlags(Vol StorageVol, Flags uint32) (rType in
 
 // DomainEventCallbackMetadataChange is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_CALLBACK_METADATA_CHANGE.
 func (l *Libvirt) DomainEventCallbackMetadataChange() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(379, constants.Program, &buf)
+	_, err = l.request(379, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14424,7 +14424,7 @@ func (l *Libvirt) DomainEventCallbackMetadataChange() (err error) {
 
 // ConnectSecretEventRegisterAny is the go wrapper for REMOTE_PROC_CONNECT_SECRET_EVENT_REGISTER_ANY.
 func (l *Libvirt) ConnectSecretEventRegisterAny(EventID int32, OptSecret OptSecret) (rCallbackID int32, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectSecretEventRegisterAnyArgs {
 		EventID: EventID,
@@ -14437,7 +14437,7 @@ func (l *Libvirt) ConnectSecretEventRegisterAny(EventID int32, OptSecret OptSecr
 	}
 
 	var r response
-	r, err = l.request(380, constants.Program, &buf)
+	r, err = l.request(380, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14456,7 +14456,7 @@ func (l *Libvirt) ConnectSecretEventRegisterAny(EventID int32, OptSecret OptSecr
 
 // ConnectSecretEventDeregisterAny is the go wrapper for REMOTE_PROC_CONNECT_SECRET_EVENT_DEREGISTER_ANY.
 func (l *Libvirt) ConnectSecretEventDeregisterAny(CallbackID int32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := ConnectSecretEventDeregisterAnyArgs {
 		CallbackID: CallbackID,
@@ -14468,7 +14468,7 @@ func (l *Libvirt) ConnectSecretEventDeregisterAny(CallbackID int32) (err error) 
 	}
 
 
-	_, err = l.request(381, constants.Program, &buf)
+	_, err = l.request(381, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14478,10 +14478,10 @@ func (l *Libvirt) ConnectSecretEventDeregisterAny(CallbackID int32) (err error) 
 
 // SecretEventLifecycle is the go wrapper for REMOTE_PROC_SECRET_EVENT_LIFECYCLE.
 func (l *Libvirt) SecretEventLifecycle() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(382, constants.Program, &buf)
+	_, err = l.request(382, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14491,10 +14491,10 @@ func (l *Libvirt) SecretEventLifecycle() (err error) {
 
 // SecretEventValueChanged is the go wrapper for REMOTE_PROC_SECRET_EVENT_VALUE_CHANGED.
 func (l *Libvirt) SecretEventValueChanged() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(383, constants.Program, &buf)
+	_, err = l.request(383, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14504,7 +14504,7 @@ func (l *Libvirt) SecretEventValueChanged() (err error) {
 
 // DomainSetVcpu is the go wrapper for REMOTE_PROC_DOMAIN_SET_VCPU.
 func (l *Libvirt) DomainSetVcpu(Dom Domain, Cpumap string, State int32, Flags DomainModificationImpact) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetVcpuArgs {
 		Dom: Dom,
@@ -14519,7 +14519,7 @@ func (l *Libvirt) DomainSetVcpu(Dom Domain, Cpumap string, State int32, Flags Do
 	}
 
 
-	_, err = l.request(384, constants.Program, &buf)
+	_, err = l.request(384, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14529,10 +14529,10 @@ func (l *Libvirt) DomainSetVcpu(Dom Domain, Cpumap string, State int32, Flags Do
 
 // DomainEventBlockThreshold is the go wrapper for REMOTE_PROC_DOMAIN_EVENT_BLOCK_THRESHOLD.
 func (l *Libvirt) DomainEventBlockThreshold() (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 
-	_, err = l.request(385, constants.Program, &buf)
+	_, err = l.request(385, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14542,7 +14542,7 @@ func (l *Libvirt) DomainEventBlockThreshold() (err error) {
 
 // DomainSetBlockThreshold is the go wrapper for REMOTE_PROC_DOMAIN_SET_BLOCK_THRESHOLD.
 func (l *Libvirt) DomainSetBlockThreshold(Dom Domain, Dev string, Threshold uint64, Flags uint32) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetBlockThresholdArgs {
 		Dom: Dom,
@@ -14557,7 +14557,7 @@ func (l *Libvirt) DomainSetBlockThreshold(Dom Domain, Dev string, Threshold uint
 	}
 
 
-	_, err = l.request(386, constants.Program, &buf)
+	_, err = l.request(386, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14567,7 +14567,7 @@ func (l *Libvirt) DomainSetBlockThreshold(Dom Domain, Dev string, Threshold uint
 
 // DomainMigrateGetMaxDowntime is the go wrapper for REMOTE_PROC_DOMAIN_MIGRATE_GET_MAX_DOWNTIME.
 func (l *Libvirt) DomainMigrateGetMaxDowntime(Dom Domain, Flags uint32) (rDowntime uint64, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainMigrateGetMaxDowntimeArgs {
 		Dom: Dom,
@@ -14580,7 +14580,7 @@ func (l *Libvirt) DomainMigrateGetMaxDowntime(Dom Domain, Flags uint32) (rDownti
 	}
 
 	var r response
-	r, err = l.request(387, constants.Program, &buf)
+	r, err = l.request(387, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14599,7 +14599,7 @@ func (l *Libvirt) DomainMigrateGetMaxDowntime(Dom Domain, Flags uint32) (rDownti
 
 // DomainManagedSaveGetXMLDesc is the go wrapper for REMOTE_PROC_DOMAIN_MANAGED_SAVE_GET_XML_DESC.
 func (l *Libvirt) DomainManagedSaveGetXMLDesc(Dom Domain, Flags DomainXMLFlags) (rXML string, err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainManagedSaveGetXMLDescArgs {
 		Dom: Dom,
@@ -14612,7 +14612,7 @@ func (l *Libvirt) DomainManagedSaveGetXMLDesc(Dom Domain, Flags DomainXMLFlags) 
 	}
 
 	var r response
-	r, err = l.request(388, constants.Program, &buf)
+	r, err = l.request(388, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14631,7 +14631,7 @@ func (l *Libvirt) DomainManagedSaveGetXMLDesc(Dom Domain, Flags DomainXMLFlags) 
 
 // DomainManagedSaveDefineXML is the go wrapper for REMOTE_PROC_DOMAIN_MANAGED_SAVE_DEFINE_XML.
 func (l *Libvirt) DomainManagedSaveDefineXML(Dom Domain, Dxml OptString, Flags DomainSaveRestoreFlags) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainManagedSaveDefineXMLArgs {
 		Dom: Dom,
@@ -14645,7 +14645,7 @@ func (l *Libvirt) DomainManagedSaveDefineXML(Dom Domain, Dxml OptString, Flags D
 	}
 
 
-	_, err = l.request(389, constants.Program, &buf)
+	_, err = l.request(389, constants.Program, buf)
 	if err != nil {
 		return
 	}
@@ -14655,7 +14655,7 @@ func (l *Libvirt) DomainManagedSaveDefineXML(Dom Domain, Dxml OptString, Flags D
 
 // DomainSetLifecycleAction is the go wrapper for REMOTE_PROC_DOMAIN_SET_LIFECYCLE_ACTION.
 func (l *Libvirt) DomainSetLifecycleAction(Dom Domain, Type uint32, Action uint32, Flags DomainModificationImpact) (err error) {
-	var buf bytes.Buffer
+	var buf []byte
 
 	args := DomainSetLifecycleActionArgs {
 		Dom: Dom,
@@ -14670,7 +14670,7 @@ func (l *Libvirt) DomainSetLifecycleAction(Dom Domain, Type uint32, Action uint3
 	}
 
 
-	_, err = l.request(390, constants.Program, &buf)
+	_, err = l.request(390, constants.Program, buf)
 	if err != nil {
 		return
 	}

--- a/libvirt.go
+++ b/libvirt.go
@@ -152,7 +152,7 @@ func (l *Libvirt) Events(dom string) (<-chan DomainEvent, error) {
 		return nil, err
 	}
 
-	res, err := l.request(constants.QEMUConnectDomainMonitorEventRegister, constants.ProgramQEMU, &buf)
+	res, err := l.request(constants.QEMUConnectDomainMonitorEventRegister, constants.ProgramQEMU, buf)
 	if err != nil {
 		if err == ErrUnsupported {
 			return nil, ErrEventsNotSupported
@@ -243,7 +243,7 @@ func (l *Libvirt) Run(dom string, cmd []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	res, err := l.request(constants.QEMUDomainMonitor, constants.ProgramQEMU, &buf)
+	res, err := l.request(constants.QEMUDomainMonitor, constants.ProgramQEMU, buf)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -219,7 +219,7 @@ func TestEncode(t *testing.T) {
 		t.Error(err)
 	}
 
-	dec := xdr.NewDecoder(bytes.NewReader(buf.Bytes()))
+	dec := xdr.NewDecoder(bytes.NewReader(buf))
 	res, _, err := dec.DecodeString()
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
We only use Buffer for its internal buffer returned by Bytes() outside
encode() anyway, so there's no reason to hold on to whole Buffer object.