### PR TITLE
Use ccache in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ install:
   - curl -O -s https://libvirt.org/sources/libvirt-${LIBVIRT}.tar.${EXT}
   - tar -C /usr/src -xf libvirt-${LIBVIRT}.tar.${EXT}
   - pushd /usr/src/libvirt-${LIBVIRT}
+  - ccache --show-stats
   - |
         env PATH=/usr/lib/ccache:$PATH \
         ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc \
@@ -39,6 +40,7 @@ install:
                     --with-qemu
   - make
   - sudo make install
+  - ccache --show-stats
   - popd
   - sudo libvirtd -d -l -f libvirtd.conf
   - sudo virtlogd -d || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,20 @@ os: linux
 dist: trusty
 sudo: require
 
+cache:
+  directories:
+    - $HOME/.ccache
+
 go:
   - "1.10"
 
 env:
-  - LIBVIRT=1.2.12 EXT=gz
-  - LIBVIRT=2.3.0  EXT=xz
-  - LIBVIRT=3.1.0  EXT=xz
+  global:
+    - CCACHE_TEMPDIR=/tmp/.ccache-temp
+  matrix:
+    - LIBVIRT=1.2.12 EXT=gz
+    - LIBVIRT=2.3.0  EXT=xz
+    - LIBVIRT=3.1.0  EXT=xz
 
 before_install:
   - go get github.com/golang/lint/golint
@@ -25,6 +32,7 @@ install:
   - tar -C /usr/src -xf libvirt-${LIBVIRT}.tar.${EXT}
   - pushd /usr/src/libvirt-${LIBVIRT}
   - |
+        env PATH=/usr/lib/ccache:$PATH \
         ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc \
                     --without-polkit \
                     --without-esx --without-vbox --without-xen --without-libxl --without-lxc \


### PR DESCRIPTION
This should speed up builds as we are rebuilding the same libvirt
versions and it takes over half of test run time.