### PR TITLE
Deprecate the old pre-generation APIs

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -27,7 +27,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/url"
 	"sync"
 
 	"github.com/davecgh/go-xdr/xdr2"
@@ -85,11 +84,38 @@ func (l *Libvirt) Capabilities() ([]byte, error) {
 // Connect establishes communication with the libvirt server.
 // The underlying libvirt socket connection must be previously established.
 func (l *Libvirt) Connect() error {
-	return l.connect()
+	payload := struct {
+		Padding [3]byte
+		Name    string
+		Flags   uint32
+	}{
+		Padding: [3]byte{0x1, 0x0, 0x0},
+		Name:    "qemu:///system",
+		Flags:   0,
+	}
+
+	buf, err := encode(&payload)
+	if err != nil {
+		return err
+	}
+
+	// libvirt requires that we call auth-list prior to connecting,
+	// event when no authentication is used.
+	_, err = l.request(constants.ProcAuthList, constants.Program, buf)
+	if err != nil {
+		return err
+	}
+
+	_, err = l.request(constants.ProcConnectOpen, constants.Program, buf)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
-// Disconnect shuts down communication with the libvirt server
-// and closes the underlying net.Conn.
+// Disconnect shuts down communication with the libvirt server and closes the
+// underlying net.Conn.
 func (l *Libvirt) Disconnect() error {
 	// close event streams
 	for id := range l.events {
@@ -98,8 +124,8 @@ func (l *Libvirt) Disconnect() error {
 		}
 	}
 
-	// inform libvirt we're done
-	if err := l.disconnect(); err != nil {
+	_, err := l.request(constants.ProcConnectClose, constants.Program, nil)
+	if err != nil {
 		return err
 	}
 
@@ -107,14 +133,18 @@ func (l *Libvirt) Disconnect() error {
 }
 
 // Domains returns a list of all domains managed by libvirt.
+//
+// Deprecated: use ConnectListAllDomains instead.
 func (l *Libvirt) Domains() ([]Domain, error) {
-	// these are the flags as passed by `virsh`, defined in:
-	// src/remote/remote_protocol.x # remote_connect_list_all_domains_args
-	domains, _, err := l.ConnectListAllDomains(1, 3)
+	// these are the flags as passed by `virsh` for `virsh list --all`
+	flags := ConnectListDomainsActive | ConnectListDomainsInactive
+	domains, _, err := l.ConnectListAllDomains(1, flags)
 	return domains, err
 }
 
 // DomainState returns state of the domain managed by libvirt.
+//
+// Deprecated: use DomainGetState instead.
 func (l *Libvirt) DomainState(dom string) (DomainState, error) {
 	d, err := l.lookup(dom)
 	if err != nil {
@@ -180,45 +210,6 @@ func (l *Libvirt) Events(dom string) (<-chan DomainEvent, error) {
 	return c, nil
 }
 
-// Migrate synchronously migrates the domain specified by dom, e.g.,
-// 'prod-lb-01', to the destination hypervisor specified by dest, e.g.,
-// 'qemu+tcp://example.com/system'. The flags argument determines the
-// type of migration and how it will be performed. For more information
-// on available migration flags and their meaning, see MigrateFlag*.
-func (l *Libvirt) Migrate(dom string, dest string, flags DomainMigrateFlags) error {
-	_, err := url.Parse(dest)
-	if err != nil {
-		return err
-	}
-
-	d, err := l.lookup(dom)
-	if err != nil {
-		return err
-	}
-
-	// Two unknowns remain here , Libvirt specifies RemoteParameters
-	// and CookieIn. In testing both values are always set to 0 by virsh
-	// and the source does not provide clear definitions of their purpose.
-	// For now, using the same zero'd values as done by virsh will be Good Enough.
-	destURI := []string{dest}
-	remoteParams := []TypedParam{}
-	cookieIn := []byte{}
-	_, err = l.DomainMigratePerform3Params(d, destURI, remoteParams, cookieIn, flags)
-	return err
-}
-
-// MigrateSetMaxSpeed set the maximum migration bandwidth (in MiB/s) for a
-// domain which is being migrated to another host. Specifying a negative value
-// results in an essentially unlimited value being provided to the hypervisor.
-func (l *Libvirt) MigrateSetMaxSpeed(dom string, speed int64) error {
-	d, err := l.lookup(dom)
-	if err != nil {
-		return err
-	}
-
-	return l.DomainMigrateSetMaxSpeed(d, uint64(speed), 0)
-}
-
 // Run executes the given QAPI command against a domain's QEMU instance.
 // For a list of available QAPI commands, see:
 //	http://git.qemu.org/?p=qemu.git;a=blob;f=qapi-schema.json;hb=HEAD
@@ -266,6 +257,8 @@ func (l *Libvirt) Run(dom string, cmd []byte) ([]byte, error) {
 }
 
 // Secrets returns all secrets managed by the libvirt daemon.
+//
+// Deprecated: use ConnectListAllSecrets instead.
 func (l *Libvirt) Secrets() ([]Secret, error) {
 	secrets, _, err := l.ConnectListAllSecrets(1, 0)
 	return secrets, err
@@ -273,12 +266,16 @@ func (l *Libvirt) Secrets() ([]Secret, error) {
 
 // StoragePool returns the storage pool associated with the provided name.
 // An error is returned if the requested storage pool is not found.
+//
+// Deprecated: use StoragePoolLookupByName instead.
 func (l *Libvirt) StoragePool(name string) (StoragePool, error) {
 	return l.StoragePoolLookupByName(name)
 }
 
 // StoragePools returns a list of defined storage pools. Pools are filtered by
 // the provided flags. See StoragePools*.
+//
+// Deprecated: use ConnectListAllStoragePools instead.
 func (l *Libvirt) StoragePools(flags ConnectListAllStoragePoolsFlags) ([]StoragePool, error) {
 	pools, _, err := l.ConnectListAllStoragePools(1, flags)
 	return pools, err
@@ -288,6 +285,8 @@ func (l *Libvirt) StoragePools(flags ConnectListAllStoragePoolsFlags) ([]Storage
 // The flags argument allows additional options to be specified such as
 // cleaning up snapshot metadata. For more information on available
 // flags, see DomainUndefine*.
+//
+// Deprecated: use DomainUndefineFlags instead.
 func (l *Libvirt) Undefine(dom string, flags DomainUndefineFlagsValues) error {
 	d, err := l.lookup(dom)
 	if err != nil {
@@ -301,6 +300,8 @@ func (l *Libvirt) Undefine(dom string, flags DomainUndefineFlagsValues) error {
 // The flags argument allows additional options to be specified such as
 // allowing a graceful shutdown with SIGTERM than SIGKILL.
 // For more information on available flags, see DomainDestroy*.
+//
+// Deprecated: use DomainDestroyFlags instead.
 func (l *Libvirt) Destroy(dom string, flags DomainDestroyFlagsValues) error {
 	d, err := l.lookup(dom)
 	if err != nil {
@@ -312,6 +313,8 @@ func (l *Libvirt) Destroy(dom string, flags DomainDestroyFlagsValues) error {
 
 // XML returns a domain's raw XML definition, akin to `virsh dumpxml <domain>`.
 // See DomainXMLFlag* for optional flags.
+//
+// Deprecated: use DomainGetXMLDesc instead.
 func (l *Libvirt) XML(dom string, flags DomainXMLFlags) ([]byte, error) {
 	d, err := l.lookup(dom)
 	if err != nil {
@@ -323,12 +326,16 @@ func (l *Libvirt) XML(dom string, flags DomainXMLFlags) ([]byte, error) {
 }
 
 // DefineXML defines a domain, but does not start it.
+//
+// Deprecated: use DomainDefineXMLFlags instead.
 func (l *Libvirt) DefineXML(x []byte, flags DomainDefineFlags) error {
 	_, err := l.DomainDefineXMLFlags(string(x), flags)
 	return err
 }
 
 // Version returns the version of the libvirt daemon.
+//
+// Deprecated: use ConnectGetLibVersion instead.
 func (l *Libvirt) Version() (string, error) {
 	ver, err := l.ConnectGetLibVersion()
 	if err != nil {
@@ -350,6 +357,8 @@ func (l *Libvirt) Version() (string, error) {
 
 // Shutdown shuts down a domain. Note that the guest OS may ignore the request.
 // If flags is set to 0 then the hypervisor will choose the method of shutdown it considers best.
+//
+// Deprecated: use DomainShutdownFlags instead.
 func (l *Libvirt) Shutdown(dom string, flags DomainShutdownFlagValues) error {
 	d, err := l.lookup(dom)
 	if err != nil {
@@ -361,6 +370,8 @@ func (l *Libvirt) Shutdown(dom string, flags DomainShutdownFlagValues) error {
 
 // Reboot reboots the domain. Note that the guest OS may ignore the request.
 // If flags is set to zero, then the hypervisor will choose the method of shutdown it considers best.
+//
+// Deprecated: use DomainReboot instead.
 func (l *Libvirt) Reboot(dom string, flags DomainRebootFlagValues) error {
 	d, err := l.lookup(dom)
 	if err != nil {
@@ -371,6 +382,8 @@ func (l *Libvirt) Reboot(dom string, flags DomainRebootFlagValues) error {
 }
 
 // Reset resets domain immediately without any guest OS shutdown
+//
+// Deprecated: use DomainReset instead.
 func (l *Libvirt) Reset(dom string) error {
 	d, err := l.lookup(dom)
 	if err != nil {
@@ -401,6 +414,8 @@ type BlockLimit struct {
 //
 // Example usage:
 //  SetBlockIOTune("vm-name", "vda", BlockLimit{libvirt.QEMUBlockIOWriteBytesSec, 1000000})
+//
+// Deprecated: use DomainSetBlockIOTune instead.
 func (l *Libvirt) SetBlockIOTune(dom string, disk string, limits ...BlockLimit) error {
 	d, err := l.lookup(dom)
 	if err != nil {
@@ -418,6 +433,8 @@ func (l *Libvirt) SetBlockIOTune(dom string, disk string, limits ...BlockLimit) 
 
 // GetBlockIOTune returns a slice containing the current block I/O tunables for
 // a disk.
+//
+// Deprecated: use DomainGetBlockIOTune instead.
 func (l *Libvirt) GetBlockIOTune(dom string, disk string) ([]BlockLimit, error) {
 	d, err := l.lookup(dom)
 	if err != nil {

--- a/libvirt_test.go
+++ b/libvirt_test.go
@@ -57,27 +57,14 @@ func TestMigrate(t *testing.T) {
 		MigrateAutoConverge |
 		MigrateNonSharedDisk
 
-	if err := l.Migrate("test", "qemu+tcp://foo/system", flags); err != nil {
-		t.Fatalf("unexpected live migration error: %v", err)
+	dom, err := l.DomainLookupByName("test")
+	if err != nil {
+		t.Fatalf("failed to lookup domain: %v", err)
 	}
-}
-
-func TestMigrateInvalidDest(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
-
-	var flags DomainMigrateFlags
-	flags = MigrateLive |
-		MigratePeer2peer |
-		MigratePersistDest |
-		MigrateChangeProtection |
-		MigrateAbortOnError |
-		MigrateAutoConverge |
-		MigrateNonSharedDisk
-
-	dest := ":$'"
-	if err := l.Migrate("test", dest, flags); err == nil {
-		t.Fatalf("expected invalid dest uri %q to fail", dest)
+	dconnuri := []string{"qemu+tcp://foo/system"}
+	if _, err := l.DomainMigratePerform3Params(dom, dconnuri,
+		[]TypedParam{}, []byte{}, flags); err != nil {
+		t.Fatalf("unexpected live migration error: %v", err)
 	}
 }
 
@@ -85,7 +72,12 @@ func TestMigrateSetMaxSpeed(t *testing.T) {
 	conn := libvirttest.New()
 	l := New(conn)
 
-	if err := l.MigrateSetMaxSpeed("test", 100); err != nil {
+	dom, err := l.DomainLookupByName("test")
+	if err != nil {
+		t.Fatalf("failed to lookup domain: %v", err)
+	}
+
+	if err := l.DomainMigrateSetMaxSpeed(dom, 100, 0); err != nil {
 		t.Fatalf("unexpected error setting max speed for migrate: %v", err)
 	}
 }

--- a/rpc.go
+++ b/rpc.go
@@ -113,42 +113,6 @@ type libvirtError struct {
 	Level    uint32
 }
 
-func (l *Libvirt) connect() error {
-	payload := struct {
-		Padding [3]byte
-		Name    string
-		Flags   uint32
-	}{
-		Padding: [3]byte{0x1, 0x0, 0x0},
-		Name:    "qemu:///system",
-		Flags:   0,
-	}
-
-	buf, err := encode(&payload)
-	if err != nil {
-		return err
-	}
-
-	// libvirt requires that we call auth-list prior to connecting,
-	// event when no authentication is used.
-	_, err = l.request(constants.ProcAuthList, constants.Program, buf)
-	if err != nil {
-		return err
-	}
-
-	_, err = l.request(constants.ProcConnectOpen, constants.Program, buf)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (l *Libvirt) disconnect() error {
-	_, err := l.request(constants.ProcConnectClose, constants.Program, nil)
-	return err
-}
-
 // listen processes incoming data and routes
 // responses to their respective callback handler.
 func (l *Libvirt) listen() {


### PR DESCRIPTION
- Marked all the remaining old APIs from before the code-generator as
deprecated. These will be removed from the go-libvirt library as soon as
we're moved all the DO code over to use the generated APIs.
- Consolidated a couple of APIs whose implementation was split into
multiple files.
- Removed a couple of Migration-related calls we're no longer using.