### PR TITLE
Geoff/dereg callbacks on disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ libvirt [![GoDoc](http://godoc.org/github.com/digitalocean/go-libvirt?status.svg
 
 Package `go-libvirt` provides a pure Go interface for interacting with libvirt.
 
-Rather than using Libvirt's C bindings, this package makes use of
+Rather than using libvirt's C bindings, this package makes use of
 libvirt's RPC interface, as documented [here](https://libvirt.org/internals/rpc.html).
 Connections to the libvirt server may be local, or remote. RPC packets are encoded
 using the XDR standard as defined by [RFC 4506](https://tools.ietf.org/html/rfc4506.html).
@@ -20,6 +20,7 @@ and produces go bindings for all the remote procedures defined there.
 
 How to Use This Library
 -----------------------
+
 Once you've vendored go-libvirt into your project, you'll probably want to call
 some libvirt functions. There's some example code below showing how to connect
 to libvirt and make one such call, but once you get past the introduction you'll
@@ -108,8 +109,9 @@ import (
 )
 
 func main() {
-	//c, err := net.DialTimeout("tcp", "127.0.0.1:16509", 2*time.Second)
-	//c, err := net.DialTimeout("tcp", "192.168.1.12:16509", 2*time.Second)
+	// This dials libvirt on the local machine, but you can substitute the first
+	// two parameters with "tcp", "<ip address>:<port>" to connect to libvirt on
+	// a remote machine.
 	c, err := net.DialTimeout("unix", "/var/run/libvirt/libvirt-sock", 2*time.Second)
 	if err != nil {
 		log.Fatalf("failed to dial libvirt: %v", err)

--- a/libvirt.go
+++ b/libvirt.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 The go-libvirt Authors.
+// Copyright 2018 The go-libvirt Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libvirt.go
+++ b/libvirt.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The go-libvirt Authors.
+// Copyright 2016-2018 The go-libvirt Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -123,6 +123,10 @@ func (l *Libvirt) Disconnect() error {
 			return err
 		}
 	}
+
+	// Deregister all the callbacks so that clients with outstanding requests
+	// will unblock.
+	l.deregisterAll()
 
 	_, err := l.request(constants.ProcConnectClose, constants.Program, nil)
 	if err != nil {

--- a/rpc.go
+++ b/rpc.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 The go-libvirt Authors.
+// Copyright 2018 The go-libvirt Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -375,4 +375,28 @@ func TestLookup(t *testing.T) {
 	if d.Name != name {
 		t.Errorf("expected domain %s, got %s", name, d.Name)
 	}
+
+	// The callback should now be deregistered.
+	if _, ok := l.callbacks[id]; ok {
+		t.Error("expected callback to deregister")
+	}
+}
+
+func TestDeregisterAll(t *testing.T) {
+	conn := libvirttest.New()
+	c1 := make(chan response)
+	c2 := make(chan response)
+	l := New(conn)
+	if len(l.callbacks) != 0 {
+		t.Error("expected callback map to be empty at test start")
+	}
+	l.register(1, c1)
+	l.register(2, c2)
+	if len(l.callbacks) != 2 {
+		t.Error("expected callback map to have 2 entries after inserts")
+	}
+	l.deregisterAll()
+	if len(l.callbacks) != 0 {
+		t.Error("expected callback map to be empty after deregisterAll")
+	}
 }


### PR DESCRIPTION
Deregister all callback when disconnecting from libvirt.

Add code to deregister all callbacks on a connection with we lose or are closing the connection to libvirt. This fixes a problem where goroutines with outstanding requests waiting for replies would block forever if the libvirt connection dies, whether because disconnect is called, or the libvirt daemon crashes or restarts.