### PR TITLE
don't deregisterAll callbacks when one gets an EOF.

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -143,7 +143,6 @@ func (l *Libvirt) listen() {
 			// When the underlying connection EOFs or is closed, stop
 			// this goroutine
 			if err == io.EOF || strings.Contains(err.Error(), "use of closed network connection") {
-				l.deregisterAll()
 				return
 			}
 


### PR DESCRIPTION
The deregisterAll routine is still called when the connection is
explicitly shut down by calling Disconnect.