### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/libvirt.gen.go
+++ b/libvirt.gen.go
@@ -36,7 +36,7 @@ const (
 
 type typedParamDecoder struct {}
 
-// decodeTypedParam decodes a TypedParam. These are part of the libvirt spec,
+// Decode decodes a TypedParam. These are part of the libvirt spec,
 // and not xdr proper. TypedParams contain a name, which is called Field for
 // some reason, and a Value, which itself has a "discriminant" - an integer enum
 // encoding the actual type, and a value, the length of which varies based on


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?