### PR TITLE
regenerate with the latest release of libvirt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 os: linux
-dist: trusty
+dist: bionic
 sudo: require
 
 cache:
@@ -8,7 +8,7 @@ cache:
     - $HOME/.ccache
 
 go:
-  - "1.11"
+  - "1.12"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ env:
   global:
     - CCACHE_TEMPDIR=/tmp/.ccache-temp
   matrix:
-    - LIBVIRT=1.2.12 EXT=gz
     - LIBVIRT=2.3.0  EXT=xz
     - LIBVIRT=3.1.0  EXT=xz
+    - LIBVIRT=5.1.0  EXT=xz
 
 before_install:
   - go get golang.org/x/lint/golint

--- a/const.gen.go
+++ b/const.gen.go
@@ -19,430 +19,438 @@
 package libvirt
 
 const (
-	// ExportVar as defined in libvirt/libvirt-common.h:58
+	// ExportVar as defined in libvirt/libvirt-common.h:57
 	ExportVar = 0
-	// TypedParamFieldLength as defined in libvirt/libvirt-common.h:171
+	// TypedParamFieldLength as defined in libvirt/libvirt-common.h:170
 	TypedParamFieldLength = 80
-	// SecurityLabelBuflen as defined in libvirt/libvirt-host.h:85
+	// SecurityLabelBuflen as defined in libvirt/libvirt-host.h:84
 	SecurityLabelBuflen = 4097
-	// SecurityModelBuflen as defined in libvirt/libvirt-host.h:113
+	// SecurityModelBuflen as defined in libvirt/libvirt-host.h:112
 	SecurityModelBuflen = 257
-	// SecurityDoiBuflen as defined in libvirt/libvirt-host.h:120
+	// SecurityDoiBuflen as defined in libvirt/libvirt-host.h:119
 	SecurityDoiBuflen = 257
-	// NodeCPUStatsFieldLength as defined in libvirt/libvirt-host.h:177
+	// NodeCPUStatsFieldLength as defined in libvirt/libvirt-host.h:176
 	NodeCPUStatsFieldLength = 80
-	// NodeCPUStatsKernel as defined in libvirt/libvirt-host.h:194
+	// NodeCPUStatsKernel as defined in libvirt/libvirt-host.h:193
 	NodeCPUStatsKernel = "kernel"
-	// NodeCPUStatsUser as defined in libvirt/libvirt-host.h:202
+	// NodeCPUStatsUser as defined in libvirt/libvirt-host.h:201
 	NodeCPUStatsUser = "user"
-	// NodeCPUStatsIdle as defined in libvirt/libvirt-host.h:210
+	// NodeCPUStatsIdle as defined in libvirt/libvirt-host.h:209
 	NodeCPUStatsIdle = "idle"
-	// NodeCPUStatsIowait as defined in libvirt/libvirt-host.h:218
+	// NodeCPUStatsIowait as defined in libvirt/libvirt-host.h:217
 	NodeCPUStatsIowait = "iowait"
-	// NodeCPUStatsIntr as defined in libvirt/libvirt-host.h:226
+	// NodeCPUStatsIntr as defined in libvirt/libvirt-host.h:225
 	NodeCPUStatsIntr = "intr"
-	// NodeCPUStatsUtilization as defined in libvirt/libvirt-host.h:235
+	// NodeCPUStatsUtilization as defined in libvirt/libvirt-host.h:234
 	NodeCPUStatsUtilization = "utilization"
-	// NodeMemoryStatsFieldLength as defined in libvirt/libvirt-host.h:255
+	// NodeMemoryStatsFieldLength as defined in libvirt/libvirt-host.h:254
 	NodeMemoryStatsFieldLength = 80
-	// NodeMemoryStatsTotal as defined in libvirt/libvirt-host.h:272
+	// NodeMemoryStatsTotal as defined in libvirt/libvirt-host.h:271
 	NodeMemoryStatsTotal = "total"
-	// NodeMemoryStatsFree as defined in libvirt/libvirt-host.h:281
+	// NodeMemoryStatsFree as defined in libvirt/libvirt-host.h:280
 	NodeMemoryStatsFree = "free"
-	// NodeMemoryStatsBuffers as defined in libvirt/libvirt-host.h:289
+	// NodeMemoryStatsBuffers as defined in libvirt/libvirt-host.h:288
 	NodeMemoryStatsBuffers = "buffers"
-	// NodeMemoryStatsCached as defined in libvirt/libvirt-host.h:297
+	// NodeMemoryStatsCached as defined in libvirt/libvirt-host.h:296
 	NodeMemoryStatsCached = "cached"
-	// NodeMemorySharedPagesToScan as defined in libvirt/libvirt-host.h:318
+	// NodeMemorySharedPagesToScan as defined in libvirt/libvirt-host.h:317
 	NodeMemorySharedPagesToScan = "shm_pages_to_scan"
-	// NodeMemorySharedSleepMillisecs as defined in libvirt/libvirt-host.h:326
+	// NodeMemorySharedSleepMillisecs as defined in libvirt/libvirt-host.h:325
 	NodeMemorySharedSleepMillisecs = "shm_sleep_millisecs"
-	// NodeMemorySharedPagesShared as defined in libvirt/libvirt-host.h:334
+	// NodeMemorySharedPagesShared as defined in libvirt/libvirt-host.h:333
 	NodeMemorySharedPagesShared = "shm_pages_shared"
-	// NodeMemorySharedPagesSharing as defined in libvirt/libvirt-host.h:342
+	// NodeMemorySharedPagesSharing as defined in libvirt/libvirt-host.h:341
 	NodeMemorySharedPagesSharing = "shm_pages_sharing"
-	// NodeMemorySharedPagesUnshared as defined in libvirt/libvirt-host.h:350
+	// NodeMemorySharedPagesUnshared as defined in libvirt/libvirt-host.h:349
 	NodeMemorySharedPagesUnshared = "shm_pages_unshared"
-	// NodeMemorySharedPagesVolatile as defined in libvirt/libvirt-host.h:358
+	// NodeMemorySharedPagesVolatile as defined in libvirt/libvirt-host.h:357
 	NodeMemorySharedPagesVolatile = "shm_pages_volatile"
-	// NodeMemorySharedFullScans as defined in libvirt/libvirt-host.h:366
+	// NodeMemorySharedFullScans as defined in libvirt/libvirt-host.h:365
 	NodeMemorySharedFullScans = "shm_full_scans"
-	// NodeMemorySharedMergeAcrossNodes as defined in libvirt/libvirt-host.h:378
+	// NodeMemorySharedMergeAcrossNodes as defined in libvirt/libvirt-host.h:377
 	NodeMemorySharedMergeAcrossNodes = "shm_merge_across_nodes"
-	// NodeSevPdh as defined in libvirt/libvirt-host.h:446
+	// NodeSevPdh as defined in libvirt/libvirt-host.h:445
 	NodeSevPdh = "pdh"
-	// NodeSevCertChain as defined in libvirt/libvirt-host.h:455
+	// NodeSevCertChain as defined in libvirt/libvirt-host.h:454
 	NodeSevCertChain = "cert-chain"
-	// NodeSevCbitpos as defined in libvirt/libvirt-host.h:462
+	// NodeSevCbitpos as defined in libvirt/libvirt-host.h:461
 	NodeSevCbitpos = "cbitpos"
-	// NodeSevReducedPhysBits as defined in libvirt/libvirt-host.h:470
+	// NodeSevReducedPhysBits as defined in libvirt/libvirt-host.h:469
 	NodeSevReducedPhysBits = "reduced-phys-bits"
-	// UUIDBuflen as defined in libvirt/libvirt-host.h:555
+	// UUIDBuflen as defined in libvirt/libvirt-host.h:554
 	UUIDBuflen = 16
-	// UUIDStringBuflen as defined in libvirt/libvirt-host.h:564
+	// UUIDStringBuflen as defined in libvirt/libvirt-host.h:563
 	UUIDStringBuflen = 37
-	// DomainSchedulerCPUShares as defined in libvirt/libvirt-domain.h:315
+	// DomainSchedulerCPUShares as defined in libvirt/libvirt-domain.h:316
 	DomainSchedulerCPUShares = "cpu_shares"
-	// DomainSchedulerGlobalPeriod as defined in libvirt/libvirt-domain.h:323
+	// DomainSchedulerGlobalPeriod as defined in libvirt/libvirt-domain.h:324
 	DomainSchedulerGlobalPeriod = "global_period"
-	// DomainSchedulerGlobalQuota as defined in libvirt/libvirt-domain.h:331
+	// DomainSchedulerGlobalQuota as defined in libvirt/libvirt-domain.h:332
 	DomainSchedulerGlobalQuota = "global_quota"
-	// DomainSchedulerVCPUPeriod as defined in libvirt/libvirt-domain.h:339
+	// DomainSchedulerVCPUPeriod as defined in libvirt/libvirt-domain.h:340
 	DomainSchedulerVCPUPeriod = "vcpu_period"
-	// DomainSchedulerVCPUQuota as defined in libvirt/libvirt-domain.h:347
+	// DomainSchedulerVCPUQuota as defined in libvirt/libvirt-domain.h:348
 	DomainSchedulerVCPUQuota = "vcpu_quota"
-	// DomainSchedulerEmulatorPeriod as defined in libvirt/libvirt-domain.h:356
+	// DomainSchedulerEmulatorPeriod as defined in libvirt/libvirt-domain.h:357
 	DomainSchedulerEmulatorPeriod = "emulator_period"
-	// DomainSchedulerEmulatorQuota as defined in libvirt/libvirt-domain.h:365
+	// DomainSchedulerEmulatorQuota as defined in libvirt/libvirt-domain.h:366
 	DomainSchedulerEmulatorQuota = "emulator_quota"
-	// DomainSchedulerIothreadPeriod as defined in libvirt/libvirt-domain.h:373
+	// DomainSchedulerIothreadPeriod as defined in libvirt/libvirt-domain.h:374
 	DomainSchedulerIothreadPeriod = "iothread_period"
-	// DomainSchedulerIothreadQuota as defined in libvirt/libvirt-domain.h:381
+	// DomainSchedulerIothreadQuota as defined in libvirt/libvirt-domain.h:382
 	DomainSchedulerIothreadQuota = "iothread_quota"
-	// DomainSchedulerWeight as defined in libvirt/libvirt-domain.h:389
+	// DomainSchedulerWeight as defined in libvirt/libvirt-domain.h:390
 	DomainSchedulerWeight = "weight"
-	// DomainSchedulerCap as defined in libvirt/libvirt-domain.h:397
+	// DomainSchedulerCap as defined in libvirt/libvirt-domain.h:398
 	DomainSchedulerCap = "cap"
-	// DomainSchedulerReservation as defined in libvirt/libvirt-domain.h:405
+	// DomainSchedulerReservation as defined in libvirt/libvirt-domain.h:406
 	DomainSchedulerReservation = "reservation"
-	// DomainSchedulerLimit as defined in libvirt/libvirt-domain.h:413
+	// DomainSchedulerLimit as defined in libvirt/libvirt-domain.h:414
 	DomainSchedulerLimit = "limit"
-	// DomainSchedulerShares as defined in libvirt/libvirt-domain.h:421
+	// DomainSchedulerShares as defined in libvirt/libvirt-domain.h:422
 	DomainSchedulerShares = "shares"
-	// DomainBlockStatsFieldLength as defined in libvirt/libvirt-domain.h:479
+	// DomainBlockStatsFieldLength as defined in libvirt/libvirt-domain.h:480
 	DomainBlockStatsFieldLength = 80
-	// DomainBlockStatsReadBytes as defined in libvirt/libvirt-domain.h:487
+	// DomainBlockStatsReadBytes as defined in libvirt/libvirt-domain.h:488
 	DomainBlockStatsReadBytes = "rd_bytes"
-	// DomainBlockStatsReadReq as defined in libvirt/libvirt-domain.h:495
+	// DomainBlockStatsReadReq as defined in libvirt/libvirt-domain.h:496
 	DomainBlockStatsReadReq = "rd_operations"
-	// DomainBlockStatsReadTotalTimes as defined in libvirt/libvirt-domain.h:503
+	// DomainBlockStatsReadTotalTimes as defined in libvirt/libvirt-domain.h:504
 	DomainBlockStatsReadTotalTimes = "rd_total_times"
-	// DomainBlockStatsWriteBytes as defined in libvirt/libvirt-domain.h:511
+	// DomainBlockStatsWriteBytes as defined in libvirt/libvirt-domain.h:512
 	DomainBlockStatsWriteBytes = "wr_bytes"
-	// DomainBlockStatsWriteReq as defined in libvirt/libvirt-domain.h:519
+	// DomainBlockStatsWriteReq as defined in libvirt/libvirt-domain.h:520
 	DomainBlockStatsWriteReq = "wr_operations"
-	// DomainBlockStatsWriteTotalTimes as defined in libvirt/libvirt-domain.h:527
+	// DomainBlockStatsWriteTotalTimes as defined in libvirt/libvirt-domain.h:528
 	DomainBlockStatsWriteTotalTimes = "wr_total_times"
-	// DomainBlockStatsFlushReq as defined in libvirt/libvirt-domain.h:535
+	// DomainBlockStatsFlushReq as defined in libvirt/libvirt-domain.h:536
 	DomainBlockStatsFlushReq = "flush_operations"
-	// DomainBlockStatsFlushTotalTimes as defined in libvirt/libvirt-domain.h:543
+	// DomainBlockStatsFlushTotalTimes as defined in libvirt/libvirt-domain.h:544
 	DomainBlockStatsFlushTotalTimes = "flush_total_times"
-	// DomainBlockStatsErrs as defined in libvirt/libvirt-domain.h:550
+	// DomainBlockStatsErrs as defined in libvirt/libvirt-domain.h:551
 	DomainBlockStatsErrs = "errs"
-	// MigrateParamURI as defined in libvirt/libvirt-domain.h:849
+	// MigrateParamURI as defined in libvirt/libvirt-domain.h:850
 	MigrateParamURI = "migrate_uri"
-	// MigrateParamDestName as defined in libvirt/libvirt-domain.h:859
+	// MigrateParamDestName as defined in libvirt/libvirt-domain.h:860
 	MigrateParamDestName = "destination_name"
-	// MigrateParamDestXML as defined in libvirt/libvirt-domain.h:878
+	// MigrateParamDestXML as defined in libvirt/libvirt-domain.h:879
 	MigrateParamDestXML = "destination_xml"
-	// MigrateParamPersistXML as defined in libvirt/libvirt-domain.h:893
+	// MigrateParamPersistXML as defined in libvirt/libvirt-domain.h:894
 	MigrateParamPersistXML = "persistent_xml"
-	// MigrateParamBandwidth as defined in libvirt/libvirt-domain.h:903
+	// MigrateParamBandwidth as defined in libvirt/libvirt-domain.h:904
 	MigrateParamBandwidth = "bandwidth"
-	// MigrateParamGraphicsURI as defined in libvirt/libvirt-domain.h:924
+	// MigrateParamGraphicsURI as defined in libvirt/libvirt-domain.h:925
 	MigrateParamGraphicsURI = "graphics_uri"
-	// MigrateParamListenAddress as defined in libvirt/libvirt-domain.h:935
+	// MigrateParamListenAddress as defined in libvirt/libvirt-domain.h:936
 	MigrateParamListenAddress = "listen_address"
-	// MigrateParamMigrateDisks as defined in libvirt/libvirt-domain.h:944
+	// MigrateParamMigrateDisks as defined in libvirt/libvirt-domain.h:945
 	MigrateParamMigrateDisks = "migrate_disks"
-	// MigrateParamDisksPort as defined in libvirt/libvirt-domain.h:954
+	// MigrateParamDisksPort as defined in libvirt/libvirt-domain.h:955
 	MigrateParamDisksPort = "disks_port"
-	// MigrateParamCompression as defined in libvirt/libvirt-domain.h:964
+	// MigrateParamCompression as defined in libvirt/libvirt-domain.h:965
 	MigrateParamCompression = "compression"
-	// MigrateParamCompressionMtLevel as defined in libvirt/libvirt-domain.h:973
+	// MigrateParamCompressionMtLevel as defined in libvirt/libvirt-domain.h:974
 	MigrateParamCompressionMtLevel = "compression.mt.level"
-	// MigrateParamCompressionMtThreads as defined in libvirt/libvirt-domain.h:981
+	// MigrateParamCompressionMtThreads as defined in libvirt/libvirt-domain.h:982
 	MigrateParamCompressionMtThreads = "compression.mt.threads"
-	// MigrateParamCompressionMtDthreads as defined in libvirt/libvirt-domain.h:989
+	// MigrateParamCompressionMtDthreads as defined in libvirt/libvirt-domain.h:990
 	MigrateParamCompressionMtDthreads = "compression.mt.dthreads"
-	// MigrateParamCompressionXbzrleCache as defined in libvirt/libvirt-domain.h:997
+	// MigrateParamCompressionXbzrleCache as defined in libvirt/libvirt-domain.h:998
 	MigrateParamCompressionXbzrleCache = "compression.xbzrle.cache"
-	// MigrateParamAutoConvergeInitial as defined in libvirt/libvirt-domain.h:1006
+	// MigrateParamAutoConvergeInitial as defined in libvirt/libvirt-domain.h:1007
 	MigrateParamAutoConvergeInitial = "auto_converge.initial"
-	// MigrateParamAutoConvergeIncrement as defined in libvirt/libvirt-domain.h:1016
+	// MigrateParamAutoConvergeIncrement as defined in libvirt/libvirt-domain.h:1017
 	MigrateParamAutoConvergeIncrement = "auto_converge.increment"
-	// DomainCPUStatsCputime as defined in libvirt/libvirt-domain.h:1269
+	// DomainCPUStatsCputime as defined in libvirt/libvirt-domain.h:1270
 	DomainCPUStatsCputime = "cpu_time"
-	// DomainCPUStatsUsertime as defined in libvirt/libvirt-domain.h:1275
+	// DomainCPUStatsUsertime as defined in libvirt/libvirt-domain.h:1276
 	DomainCPUStatsUsertime = "user_time"
-	// DomainCPUStatsSystemtime as defined in libvirt/libvirt-domain.h:1281
+	// DomainCPUStatsSystemtime as defined in libvirt/libvirt-domain.h:1282
 	DomainCPUStatsSystemtime = "system_time"
-	// DomainCPUStatsVcputime as defined in libvirt/libvirt-domain.h:1288
+	// DomainCPUStatsVcputime as defined in libvirt/libvirt-domain.h:1289
 	DomainCPUStatsVcputime = "vcpu_time"
-	// DomainBlkioWeight as defined in libvirt/libvirt-domain.h:1317
+	// DomainBlkioWeight as defined in libvirt/libvirt-domain.h:1318
 	DomainBlkioWeight = "weight"
-	// DomainBlkioDeviceWeight as defined in libvirt/libvirt-domain.h:1327
+	// DomainBlkioDeviceWeight as defined in libvirt/libvirt-domain.h:1328
 	DomainBlkioDeviceWeight = "device_weight"
-	// DomainBlkioDeviceReadIops as defined in libvirt/libvirt-domain.h:1338
+	// DomainBlkioDeviceReadIops as defined in libvirt/libvirt-domain.h:1339
 	DomainBlkioDeviceReadIops = "device_read_iops_sec"
-	// DomainBlkioDeviceWriteIops as defined in libvirt/libvirt-domain.h:1349
+	// DomainBlkioDeviceWriteIops as defined in libvirt/libvirt-domain.h:1350
 	DomainBlkioDeviceWriteIops = "device_write_iops_sec"
-	// DomainBlkioDeviceReadBps as defined in libvirt/libvirt-domain.h:1360
+	// DomainBlkioDeviceReadBps as defined in libvirt/libvirt-domain.h:1361
 	DomainBlkioDeviceReadBps = "device_read_bytes_sec"
-	// DomainBlkioDeviceWriteBps as defined in libvirt/libvirt-domain.h:1371
+	// DomainBlkioDeviceWriteBps as defined in libvirt/libvirt-domain.h:1372
 	DomainBlkioDeviceWriteBps = "device_write_bytes_sec"
-	// DomainMemoryParamUnlimited as defined in libvirt/libvirt-domain.h:1390
+	// DomainMemoryParamUnlimited as defined in libvirt/libvirt-domain.h:1391
 	DomainMemoryParamUnlimited = 9007199254740991
-	// DomainMemoryHardLimit as defined in libvirt/libvirt-domain.h:1399
+	// DomainMemoryHardLimit as defined in libvirt/libvirt-domain.h:1400
 	DomainMemoryHardLimit = "hard_limit"
-	// DomainMemorySoftLimit as defined in libvirt/libvirt-domain.h:1408
+	// DomainMemorySoftLimit as defined in libvirt/libvirt-domain.h:1409
 	DomainMemorySoftLimit = "soft_limit"
-	// DomainMemoryMinGuarantee as defined in libvirt/libvirt-domain.h:1417
+	// DomainMemoryMinGuarantee as defined in libvirt/libvirt-domain.h:1418
 	DomainMemoryMinGuarantee = "min_guarantee"
-	// DomainMemorySwapHardLimit as defined in libvirt/libvirt-domain.h:1427
+	// DomainMemorySwapHardLimit as defined in libvirt/libvirt-domain.h:1428
 	DomainMemorySwapHardLimit = "swap_hard_limit"
-	// DomainNumaNodeset as defined in libvirt/libvirt-domain.h:1472
+	// DomainNumaNodeset as defined in libvirt/libvirt-domain.h:1473
 	DomainNumaNodeset = "numa_nodeset"
-	// DomainNumaMode as defined in libvirt/libvirt-domain.h:1480
+	// DomainNumaMode as defined in libvirt/libvirt-domain.h:1481
 	DomainNumaMode = "numa_mode"
-	// DomainBandwidthInAverage as defined in libvirt/libvirt-domain.h:1592
+	// DomainBandwidthInAverage as defined in libvirt/libvirt-domain.h:1593
 	DomainBandwidthInAverage = "inbound.average"
-	// DomainBandwidthInPeak as defined in libvirt/libvirt-domain.h:1599
+	// DomainBandwidthInPeak as defined in libvirt/libvirt-domain.h:1600
 	DomainBandwidthInPeak = "inbound.peak"
-	// DomainBandwidthInBurst as defined in libvirt/libvirt-domain.h:1606
+	// DomainBandwidthInBurst as defined in libvirt/libvirt-domain.h:1607
 	DomainBandwidthInBurst = "inbound.burst"
-	// DomainBandwidthInFloor as defined in libvirt/libvirt-domain.h:1613
+	// DomainBandwidthInFloor as defined in libvirt/libvirt-domain.h:1614
 	DomainBandwidthInFloor = "inbound.floor"
-	// DomainBandwidthOutAverage as defined in libvirt/libvirt-domain.h:1620
+	// DomainBandwidthOutAverage as defined in libvirt/libvirt-domain.h:1621
 	DomainBandwidthOutAverage = "outbound.average"
-	// DomainBandwidthOutPeak as defined in libvirt/libvirt-domain.h:1627
+	// DomainBandwidthOutPeak as defined in libvirt/libvirt-domain.h:1628
 	DomainBandwidthOutPeak = "outbound.peak"
-	// DomainBandwidthOutBurst as defined in libvirt/libvirt-domain.h:1634
+	// DomainBandwidthOutBurst as defined in libvirt/libvirt-domain.h:1635
 	DomainBandwidthOutBurst = "outbound.burst"
-	// PerfParamCmt as defined in libvirt/libvirt-domain.h:2095
+	// DomainIothreadPollMaxNs as defined in libvirt/libvirt-domain.h:1929
+	DomainIothreadPollMaxNs = "poll_max_ns"
+	// DomainIothreadPollGrow as defined in libvirt/libvirt-domain.h:1939
+	DomainIothreadPollGrow = "poll_grow"
+	// DomainIothreadPollShrink as defined in libvirt/libvirt-domain.h:1950
+	DomainIothreadPollShrink = "poll_shrink"
+	// PerfParamCmt as defined in libvirt/libvirt-domain.h:2141
 	PerfParamCmt = "cmt"
-	// PerfParamMbmt as defined in libvirt/libvirt-domain.h:2106
+	// PerfParamMbmt as defined in libvirt/libvirt-domain.h:2152
 	PerfParamMbmt = "mbmt"
-	// PerfParamMbml as defined in libvirt/libvirt-domain.h:2116
+	// PerfParamMbml as defined in libvirt/libvirt-domain.h:2162
 	PerfParamMbml = "mbml"
-	// PerfParamCacheMisses as defined in libvirt/libvirt-domain.h:2126
+	// PerfParamCacheMisses as defined in libvirt/libvirt-domain.h:2172
 	PerfParamCacheMisses = "cache_misses"
-	// PerfParamCacheReferences as defined in libvirt/libvirt-domain.h:2136
+	// PerfParamCacheReferences as defined in libvirt/libvirt-domain.h:2182
 	PerfParamCacheReferences = "cache_references"
-	// PerfParamInstructions as defined in libvirt/libvirt-domain.h:2146
+	// PerfParamInstructions as defined in libvirt/libvirt-domain.h:2192
 	PerfParamInstructions = "instructions"
-	// PerfParamCPUCycles as defined in libvirt/libvirt-domain.h:2156
+	// PerfParamCPUCycles as defined in libvirt/libvirt-domain.h:2202
 	PerfParamCPUCycles = "cpu_cycles"
-	// PerfParamBranchInstructions as defined in libvirt/libvirt-domain.h:2166
+	// PerfParamBranchInstructions as defined in libvirt/libvirt-domain.h:2212
 	PerfParamBranchInstructions = "branch_instructions"
-	// PerfParamBranchMisses as defined in libvirt/libvirt-domain.h:2176
+	// PerfParamBranchMisses as defined in libvirt/libvirt-domain.h:2222
 	PerfParamBranchMisses = "branch_misses"
-	// PerfParamBusCycles as defined in libvirt/libvirt-domain.h:2186
+	// PerfParamBusCycles as defined in libvirt/libvirt-domain.h:2232
 	PerfParamBusCycles = "bus_cycles"
-	// PerfParamStalledCyclesFrontend as defined in libvirt/libvirt-domain.h:2197
+	// PerfParamStalledCyclesFrontend as defined in libvirt/libvirt-domain.h:2243
 	PerfParamStalledCyclesFrontend = "stalled_cycles_frontend"
-	// PerfParamStalledCyclesBackend as defined in libvirt/libvirt-domain.h:2208
+	// PerfParamStalledCyclesBackend as defined in libvirt/libvirt-domain.h:2254
 	PerfParamStalledCyclesBackend = "stalled_cycles_backend"
-	// PerfParamRefCPUCycles as defined in libvirt/libvirt-domain.h:2219
+	// PerfParamRefCPUCycles as defined in libvirt/libvirt-domain.h:2265
 	PerfParamRefCPUCycles = "ref_cpu_cycles"
-	// PerfParamCPUClock as defined in libvirt/libvirt-domain.h:2230
+	// PerfParamCPUClock as defined in libvirt/libvirt-domain.h:2276
 	PerfParamCPUClock = "cpu_clock"
-	// PerfParamTaskClock as defined in libvirt/libvirt-domain.h:2241
+	// PerfParamTaskClock as defined in libvirt/libvirt-domain.h:2287
 	PerfParamTaskClock = "task_clock"
-	// PerfParamPageFaults as defined in libvirt/libvirt-domain.h:2251
+	// PerfParamPageFaults as defined in libvirt/libvirt-domain.h:2297
 	PerfParamPageFaults = "page_faults"
-	// PerfParamContextSwitches as defined in libvirt/libvirt-domain.h:2261
+	// PerfParamContextSwitches as defined in libvirt/libvirt-domain.h:2307
 	PerfParamContextSwitches = "context_switches"
-	// PerfParamCPUMigrations as defined in libvirt/libvirt-domain.h:2271
+	// PerfParamCPUMigrations as defined in libvirt/libvirt-domain.h:2317
 	PerfParamCPUMigrations = "cpu_migrations"
-	// PerfParamPageFaultsMin as defined in libvirt/libvirt-domain.h:2281
+	// PerfParamPageFaultsMin as defined in libvirt/libvirt-domain.h:2327
 	PerfParamPageFaultsMin = "page_faults_min"
-	// PerfParamPageFaultsMaj as defined in libvirt/libvirt-domain.h:2291
+	// PerfParamPageFaultsMaj as defined in libvirt/libvirt-domain.h:2337
 	PerfParamPageFaultsMaj = "page_faults_maj"
-	// PerfParamAlignmentFaults as defined in libvirt/libvirt-domain.h:2301
+	// PerfParamAlignmentFaults as defined in libvirt/libvirt-domain.h:2347
 	PerfParamAlignmentFaults = "alignment_faults"
-	// PerfParamEmulationFaults as defined in libvirt/libvirt-domain.h:2311
+	// PerfParamEmulationFaults as defined in libvirt/libvirt-domain.h:2357
 	PerfParamEmulationFaults = "emulation_faults"
-	// DomainBlockCopyBandwidth as defined in libvirt/libvirt-domain.h:2475
+	// DomainBlockCopyBandwidth as defined in libvirt/libvirt-domain.h:2521
 	DomainBlockCopyBandwidth = "bandwidth"
-	// DomainBlockCopyGranularity as defined in libvirt/libvirt-domain.h:2486
+	// DomainBlockCopyGranularity as defined in libvirt/libvirt-domain.h:2532
 	DomainBlockCopyGranularity = "granularity"
-	// DomainBlockCopyBufSize as defined in libvirt/libvirt-domain.h:2495
+	// DomainBlockCopyBufSize as defined in libvirt/libvirt-domain.h:2541
 	DomainBlockCopyBufSize = "buf-size"
-	// DomainBlockIotuneTotalBytesSec as defined in libvirt/libvirt-domain.h:2536
+	// DomainBlockIotuneTotalBytesSec as defined in libvirt/libvirt-domain.h:2582
 	DomainBlockIotuneTotalBytesSec = "total_bytes_sec"
-	// DomainBlockIotuneReadBytesSec as defined in libvirt/libvirt-domain.h:2544
+	// DomainBlockIotuneReadBytesSec as defined in libvirt/libvirt-domain.h:2590
 	DomainBlockIotuneReadBytesSec = "read_bytes_sec"
-	// DomainBlockIotuneWriteBytesSec as defined in libvirt/libvirt-domain.h:2552
+	// DomainBlockIotuneWriteBytesSec as defined in libvirt/libvirt-domain.h:2598
 	DomainBlockIotuneWriteBytesSec = "write_bytes_sec"
-	// DomainBlockIotuneTotalIopsSec as defined in libvirt/libvirt-domain.h:2560
+	// DomainBlockIotuneTotalIopsSec as defined in libvirt/libvirt-domain.h:2606
 	DomainBlockIotuneTotalIopsSec = "total_iops_sec"
-	// DomainBlockIotuneReadIopsSec as defined in libvirt/libvirt-domain.h:2568
+	// DomainBlockIotuneReadIopsSec as defined in libvirt/libvirt-domain.h:2614
 	DomainBlockIotuneReadIopsSec = "read_iops_sec"
-	// DomainBlockIotuneWriteIopsSec as defined in libvirt/libvirt-domain.h:2575
+	// DomainBlockIotuneWriteIopsSec as defined in libvirt/libvirt-domain.h:2621
 	DomainBlockIotuneWriteIopsSec = "write_iops_sec"
-	// DomainBlockIotuneTotalBytesSecMax as defined in libvirt/libvirt-domain.h:2583
+	// DomainBlockIotuneTotalBytesSecMax as defined in libvirt/libvirt-domain.h:2629
 	DomainBlockIotuneTotalBytesSecMax = "total_bytes_sec_max"
-	// DomainBlockIotuneReadBytesSecMax as defined in libvirt/libvirt-domain.h:2591
+	// DomainBlockIotuneReadBytesSecMax as defined in libvirt/libvirt-domain.h:2637
 	DomainBlockIotuneReadBytesSecMax = "read_bytes_sec_max"
-	// DomainBlockIotuneWriteBytesSecMax as defined in libvirt/libvirt-domain.h:2599
+	// DomainBlockIotuneWriteBytesSecMax as defined in libvirt/libvirt-domain.h:2645
 	DomainBlockIotuneWriteBytesSecMax = "write_bytes_sec_max"
-	// DomainBlockIotuneTotalIopsSecMax as defined in libvirt/libvirt-domain.h:2607
+	// DomainBlockIotuneTotalIopsSecMax as defined in libvirt/libvirt-domain.h:2653
 	DomainBlockIotuneTotalIopsSecMax = "total_iops_sec_max"
-	// DomainBlockIotuneReadIopsSecMax as defined in libvirt/libvirt-domain.h:2615
+	// DomainBlockIotuneReadIopsSecMax as defined in libvirt/libvirt-domain.h:2661
 	DomainBlockIotuneReadIopsSecMax = "read_iops_sec_max"
-	// DomainBlockIotuneWriteIopsSecMax as defined in libvirt/libvirt-domain.h:2622
+	// DomainBlockIotuneWriteIopsSecMax as defined in libvirt/libvirt-domain.h:2668
 	DomainBlockIotuneWriteIopsSecMax = "write_iops_sec_max"
-	// DomainBlockIotuneTotalBytesSecMaxLength as defined in libvirt/libvirt-domain.h:2630
+	// DomainBlockIotuneTotalBytesSecMaxLength as defined in libvirt/libvirt-domain.h:2676
 	DomainBlockIotuneTotalBytesSecMaxLength = "total_bytes_sec_max_length"
-	// DomainBlockIotuneReadBytesSecMaxLength as defined in libvirt/libvirt-domain.h:2638
+	// DomainBlockIotuneReadBytesSecMaxLength as defined in libvirt/libvirt-domain.h:2684
 	DomainBlockIotuneReadBytesSecMaxLength = "read_bytes_sec_max_length"
-	// DomainBlockIotuneWriteBytesSecMaxLength as defined in libvirt/libvirt-domain.h:2646
+	// DomainBlockIotuneWriteBytesSecMaxLength as defined in libvirt/libvirt-domain.h:2692
 	DomainBlockIotuneWriteBytesSecMaxLength = "write_bytes_sec_max_length"
-	// DomainBlockIotuneTotalIopsSecMaxLength as defined in libvirt/libvirt-domain.h:2654
+	// DomainBlockIotuneTotalIopsSecMaxLength as defined in libvirt/libvirt-domain.h:2700
 	DomainBlockIotuneTotalIopsSecMaxLength = "total_iops_sec_max_length"
-	// DomainBlockIotuneReadIopsSecMaxLength as defined in libvirt/libvirt-domain.h:2662
+	// DomainBlockIotuneReadIopsSecMaxLength as defined in libvirt/libvirt-domain.h:2708
 	DomainBlockIotuneReadIopsSecMaxLength = "read_iops_sec_max_length"
-	// DomainBlockIotuneWriteIopsSecMaxLength as defined in libvirt/libvirt-domain.h:2670
+	// DomainBlockIotuneWriteIopsSecMaxLength as defined in libvirt/libvirt-domain.h:2716
 	DomainBlockIotuneWriteIopsSecMaxLength = "write_iops_sec_max_length"
-	// DomainBlockIotuneSizeIopsSec as defined in libvirt/libvirt-domain.h:2677
+	// DomainBlockIotuneSizeIopsSec as defined in libvirt/libvirt-domain.h:2723
 	DomainBlockIotuneSizeIopsSec = "size_iops_sec"
-	// DomainBlockIotuneGroupName as defined in libvirt/libvirt-domain.h:2684
+	// DomainBlockIotuneGroupName as defined in libvirt/libvirt-domain.h:2730
 	DomainBlockIotuneGroupName = "group_name"
-	// KeycodeSetRfb as defined in libvirt/libvirt-domain.h:2765
+	// KeycodeSetRfb as defined in libvirt/libvirt-domain.h:2811
 	KeycodeSetRfb = 0
-	// DomainSendKeyMaxKeys as defined in libvirt/libvirt-domain.h:2772
+	// DomainSendKeyMaxKeys as defined in libvirt/libvirt-domain.h:2818
 	DomainSendKeyMaxKeys = 16
-	// DomainJobOperationStr as defined in libvirt/libvirt-domain.h:3184
+	// DomainJobOperationStr as defined in libvirt/libvirt-domain.h:3230
 	DomainJobOperationStr = "operation"
-	// DomainJobTimeElapsed as defined in libvirt/libvirt-domain.h:3194
+	// DomainJobTimeElapsed as defined in libvirt/libvirt-domain.h:3240
 	DomainJobTimeElapsed = "time_elapsed"
-	// DomainJobTimeElapsedNet as defined in libvirt/libvirt-domain.h:3204
+	// DomainJobTimeElapsedNet as defined in libvirt/libvirt-domain.h:3250
 	DomainJobTimeElapsedNet = "time_elapsed_net"
-	// DomainJobTimeRemaining as defined in libvirt/libvirt-domain.h:3214
+	// DomainJobTimeRemaining as defined in libvirt/libvirt-domain.h:3260
 	DomainJobTimeRemaining = "time_remaining"
-	// DomainJobDowntime as defined in libvirt/libvirt-domain.h:3224
+	// DomainJobDowntime as defined in libvirt/libvirt-domain.h:3270
 	DomainJobDowntime = "downtime"
-	// DomainJobDowntimeNet as defined in libvirt/libvirt-domain.h:3233
+	// DomainJobDowntimeNet as defined in libvirt/libvirt-domain.h:3279
 	DomainJobDowntimeNet = "downtime_net"
-	// DomainJobSetupTime as defined in libvirt/libvirt-domain.h:3242
+	// DomainJobSetupTime as defined in libvirt/libvirt-domain.h:3288
 	DomainJobSetupTime = "setup_time"
-	// DomainJobDataTotal as defined in libvirt/libvirt-domain.h:3257
+	// DomainJobDataTotal as defined in libvirt/libvirt-domain.h:3303
 	DomainJobDataTotal = "data_total"
-	// DomainJobDataProcessed as defined in libvirt/libvirt-domain.h:3267
+	// DomainJobDataProcessed as defined in libvirt/libvirt-domain.h:3313
 	DomainJobDataProcessed = "data_processed"
-	// DomainJobDataRemaining as defined in libvirt/libvirt-domain.h:3277
+	// DomainJobDataRemaining as defined in libvirt/libvirt-domain.h:3323
 	DomainJobDataRemaining = "data_remaining"
-	// DomainJobMemoryTotal as defined in libvirt/libvirt-domain.h:3287
+	// DomainJobMemoryTotal as defined in libvirt/libvirt-domain.h:3333
 	DomainJobMemoryTotal = "memory_total"
-	// DomainJobMemoryProcessed as defined in libvirt/libvirt-domain.h:3297
+	// DomainJobMemoryProcessed as defined in libvirt/libvirt-domain.h:3343
 	DomainJobMemoryProcessed = "memory_processed"
-	// DomainJobMemoryRemaining as defined in libvirt/libvirt-domain.h:3307
+	// DomainJobMemoryRemaining as defined in libvirt/libvirt-domain.h:3353
 	DomainJobMemoryRemaining = "memory_remaining"
-	// DomainJobMemoryConstant as defined in libvirt/libvirt-domain.h:3319
+	// DomainJobMemoryConstant as defined in libvirt/libvirt-domain.h:3365
 	DomainJobMemoryConstant = "memory_constant"
-	// DomainJobMemoryNormal as defined in libvirt/libvirt-domain.h:3329
+	// DomainJobMemoryNormal as defined in libvirt/libvirt-domain.h:3375
 	DomainJobMemoryNormal = "memory_normal"
-	// DomainJobMemoryNormalBytes as defined in libvirt/libvirt-domain.h:3339
+	// DomainJobMemoryNormalBytes as defined in libvirt/libvirt-domain.h:3385
 	DomainJobMemoryNormalBytes = "memory_normal_bytes"
-	// DomainJobMemoryBps as defined in libvirt/libvirt-domain.h:3347
+	// DomainJobMemoryBps as defined in libvirt/libvirt-domain.h:3393
 	DomainJobMemoryBps = "memory_bps"
-	// DomainJobMemoryDirtyRate as defined in libvirt/libvirt-domain.h:3355
+	// DomainJobMemoryDirtyRate as defined in libvirt/libvirt-domain.h:3401
 	DomainJobMemoryDirtyRate = "memory_dirty_rate"
-	// DomainJobMemoryPageSize as defined in libvirt/libvirt-domain.h:3366
+	// DomainJobMemoryPageSize as defined in libvirt/libvirt-domain.h:3412
 	DomainJobMemoryPageSize = "memory_page_size"
-	// DomainJobMemoryIteration as defined in libvirt/libvirt-domain.h:3377
+	// DomainJobMemoryIteration as defined in libvirt/libvirt-domain.h:3423
 	DomainJobMemoryIteration = "memory_iteration"
-	// DomainJobDiskTotal as defined in libvirt/libvirt-domain.h:3387
+	// DomainJobMemoryPostcopyReqs as defined in libvirt/libvirt-domain.h:3433
+	DomainJobMemoryPostcopyReqs = "memory_postcopy_requests"
+	// DomainJobDiskTotal as defined in libvirt/libvirt-domain.h:3443
 	DomainJobDiskTotal = "disk_total"
-	// DomainJobDiskProcessed as defined in libvirt/libvirt-domain.h:3397
+	// DomainJobDiskProcessed as defined in libvirt/libvirt-domain.h:3453
 	DomainJobDiskProcessed = "disk_processed"
-	// DomainJobDiskRemaining as defined in libvirt/libvirt-domain.h:3407
+	// DomainJobDiskRemaining as defined in libvirt/libvirt-domain.h:3463
 	DomainJobDiskRemaining = "disk_remaining"
-	// DomainJobDiskBps as defined in libvirt/libvirt-domain.h:3415
+	// DomainJobDiskBps as defined in libvirt/libvirt-domain.h:3471
 	DomainJobDiskBps = "disk_bps"
-	// DomainJobCompressionCache as defined in libvirt/libvirt-domain.h:3424
+	// DomainJobCompressionCache as defined in libvirt/libvirt-domain.h:3480
 	DomainJobCompressionCache = "compression_cache"
-	// DomainJobCompressionBytes as defined in libvirt/libvirt-domain.h:3432
+	// DomainJobCompressionBytes as defined in libvirt/libvirt-domain.h:3488
 	DomainJobCompressionBytes = "compression_bytes"
-	// DomainJobCompressionPages as defined in libvirt/libvirt-domain.h:3440
+	// DomainJobCompressionPages as defined in libvirt/libvirt-domain.h:3496
 	DomainJobCompressionPages = "compression_pages"
-	// DomainJobCompressionCacheMisses as defined in libvirt/libvirt-domain.h:3449
+	// DomainJobCompressionCacheMisses as defined in libvirt/libvirt-domain.h:3505
 	DomainJobCompressionCacheMisses = "compression_cache_misses"
-	// DomainJobCompressionOverflow as defined in libvirt/libvirt-domain.h:3459
+	// DomainJobCompressionOverflow as defined in libvirt/libvirt-domain.h:3515
 	DomainJobCompressionOverflow = "compression_overflow"
-	// DomainJobAutoConvergeThrottle as defined in libvirt/libvirt-domain.h:3468
+	// DomainJobAutoConvergeThrottle as defined in libvirt/libvirt-domain.h:3524
 	DomainJobAutoConvergeThrottle = "auto_converge_throttle"
-	// DomainTunableCPUVcpupin as defined in libvirt/libvirt-domain.h:4022
+	// DomainTunableCPUVcpupin as defined in libvirt/libvirt-domain.h:4078
 	DomainTunableCPUVcpupin = "cputune.vcpupin%u"
-	// DomainTunableCPUEmulatorpin as defined in libvirt/libvirt-domain.h:4030
+	// DomainTunableCPUEmulatorpin as defined in libvirt/libvirt-domain.h:4086
 	DomainTunableCPUEmulatorpin = "cputune.emulatorpin"
-	// DomainTunableCPUIothreadspin as defined in libvirt/libvirt-domain.h:4039
+	// DomainTunableCPUIothreadspin as defined in libvirt/libvirt-domain.h:4095
 	DomainTunableCPUIothreadspin = "cputune.iothreadpin%u"
-	// DomainTunableCPUCpuShares as defined in libvirt/libvirt-domain.h:4047
+	// DomainTunableCPUCpuShares as defined in libvirt/libvirt-domain.h:4103
 	DomainTunableCPUCpuShares = "cputune.cpu_shares"
-	// DomainTunableCPUGlobalPeriod as defined in libvirt/libvirt-domain.h:4055
+	// DomainTunableCPUGlobalPeriod as defined in libvirt/libvirt-domain.h:4111
 	DomainTunableCPUGlobalPeriod = "cputune.global_period"
-	// DomainTunableCPUGlobalQuota as defined in libvirt/libvirt-domain.h:4063
+	// DomainTunableCPUGlobalQuota as defined in libvirt/libvirt-domain.h:4119
 	DomainTunableCPUGlobalQuota = "cputune.global_quota"
-	// DomainTunableCPUVCPUPeriod as defined in libvirt/libvirt-domain.h:4071
+	// DomainTunableCPUVCPUPeriod as defined in libvirt/libvirt-domain.h:4127
 	DomainTunableCPUVCPUPeriod = "cputune.vcpu_period"
-	// DomainTunableCPUVCPUQuota as defined in libvirt/libvirt-domain.h:4079
+	// DomainTunableCPUVCPUQuota as defined in libvirt/libvirt-domain.h:4135
 	DomainTunableCPUVCPUQuota = "cputune.vcpu_quota"
-	// DomainTunableCPUEmulatorPeriod as defined in libvirt/libvirt-domain.h:4088
+	// DomainTunableCPUEmulatorPeriod as defined in libvirt/libvirt-domain.h:4144
 	DomainTunableCPUEmulatorPeriod = "cputune.emulator_period"
-	// DomainTunableCPUEmulatorQuota as defined in libvirt/libvirt-domain.h:4097
+	// DomainTunableCPUEmulatorQuota as defined in libvirt/libvirt-domain.h:4153
 	DomainTunableCPUEmulatorQuota = "cputune.emulator_quota"
-	// DomainTunableCPUIothreadPeriod as defined in libvirt/libvirt-domain.h:4105
+	// DomainTunableCPUIothreadPeriod as defined in libvirt/libvirt-domain.h:4161
 	DomainTunableCPUIothreadPeriod = "cputune.iothread_period"
-	// DomainTunableCPUIothreadQuota as defined in libvirt/libvirt-domain.h:4113
+	// DomainTunableCPUIothreadQuota as defined in libvirt/libvirt-domain.h:4169
 	DomainTunableCPUIothreadQuota = "cputune.iothread_quota"
-	// DomainTunableBlkdevDisk as defined in libvirt/libvirt-domain.h:4121
+	// DomainTunableBlkdevDisk as defined in libvirt/libvirt-domain.h:4177
 	DomainTunableBlkdevDisk = "blkdeviotune.disk"
-	// DomainTunableBlkdevTotalBytesSec as defined in libvirt/libvirt-domain.h:4129
+	// DomainTunableBlkdevTotalBytesSec as defined in libvirt/libvirt-domain.h:4185
 	DomainTunableBlkdevTotalBytesSec = "blkdeviotune.total_bytes_sec"
-	// DomainTunableBlkdevReadBytesSec as defined in libvirt/libvirt-domain.h:4137
+	// DomainTunableBlkdevReadBytesSec as defined in libvirt/libvirt-domain.h:4193
 	DomainTunableBlkdevReadBytesSec = "blkdeviotune.read_bytes_sec"
-	// DomainTunableBlkdevWriteBytesSec as defined in libvirt/libvirt-domain.h:4145
+	// DomainTunableBlkdevWriteBytesSec as defined in libvirt/libvirt-domain.h:4201
 	DomainTunableBlkdevWriteBytesSec = "blkdeviotune.write_bytes_sec"
-	// DomainTunableBlkdevTotalIopsSec as defined in libvirt/libvirt-domain.h:4153
+	// DomainTunableBlkdevTotalIopsSec as defined in libvirt/libvirt-domain.h:4209
 	DomainTunableBlkdevTotalIopsSec = "blkdeviotune.total_iops_sec"
-	// DomainTunableBlkdevReadIopsSec as defined in libvirt/libvirt-domain.h:4161
+	// DomainTunableBlkdevReadIopsSec as defined in libvirt/libvirt-domain.h:4217
 	DomainTunableBlkdevReadIopsSec = "blkdeviotune.read_iops_sec"
-	// DomainTunableBlkdevWriteIopsSec as defined in libvirt/libvirt-domain.h:4169
+	// DomainTunableBlkdevWriteIopsSec as defined in libvirt/libvirt-domain.h:4225
 	DomainTunableBlkdevWriteIopsSec = "blkdeviotune.write_iops_sec"
-	// DomainTunableBlkdevTotalBytesSecMax as defined in libvirt/libvirt-domain.h:4177
+	// DomainTunableBlkdevTotalBytesSecMax as defined in libvirt/libvirt-domain.h:4233
 	DomainTunableBlkdevTotalBytesSecMax = "blkdeviotune.total_bytes_sec_max"
-	// DomainTunableBlkdevReadBytesSecMax as defined in libvirt/libvirt-domain.h:4185
+	// DomainTunableBlkdevReadBytesSecMax as defined in libvirt/libvirt-domain.h:4241
 	DomainTunableBlkdevReadBytesSecMax = "blkdeviotune.read_bytes_sec_max"
-	// DomainTunableBlkdevWriteBytesSecMax as defined in libvirt/libvirt-domain.h:4193
+	// DomainTunableBlkdevWriteBytesSecMax as defined in libvirt/libvirt-domain.h:4249
 	DomainTunableBlkdevWriteBytesSecMax = "blkdeviotune.write_bytes_sec_max"
-	// DomainTunableBlkdevTotalIopsSecMax as defined in libvirt/libvirt-domain.h:4201
+	// DomainTunableBlkdevTotalIopsSecMax as defined in libvirt/libvirt-domain.h:4257
 	DomainTunableBlkdevTotalIopsSecMax = "blkdeviotune.total_iops_sec_max"
-	// DomainTunableBlkdevReadIopsSecMax as defined in libvirt/libvirt-domain.h:4209
+	// DomainTunableBlkdevReadIopsSecMax as defined in libvirt/libvirt-domain.h:4265
 	DomainTunableBlkdevReadIopsSecMax = "blkdeviotune.read_iops_sec_max"
-	// DomainTunableBlkdevWriteIopsSecMax as defined in libvirt/libvirt-domain.h:4217
+	// DomainTunableBlkdevWriteIopsSecMax as defined in libvirt/libvirt-domain.h:4273
 	DomainTunableBlkdevWriteIopsSecMax = "blkdeviotune.write_iops_sec_max"
-	// DomainTunableBlkdevSizeIopsSec as defined in libvirt/libvirt-domain.h:4225
+	// DomainTunableBlkdevSizeIopsSec as defined in libvirt/libvirt-domain.h:4281
 	DomainTunableBlkdevSizeIopsSec = "blkdeviotune.size_iops_sec"
-	// DomainTunableBlkdevGroupName as defined in libvirt/libvirt-domain.h:4233
+	// DomainTunableBlkdevGroupName as defined in libvirt/libvirt-domain.h:4289
 	DomainTunableBlkdevGroupName = "blkdeviotune.group_name"
-	// DomainTunableBlkdevTotalBytesSecMaxLength as defined in libvirt/libvirt-domain.h:4242
+	// DomainTunableBlkdevTotalBytesSecMaxLength as defined in libvirt/libvirt-domain.h:4298
 	DomainTunableBlkdevTotalBytesSecMaxLength = "blkdeviotune.total_bytes_sec_max_length"
-	// DomainTunableBlkdevReadBytesSecMaxLength as defined in libvirt/libvirt-domain.h:4251
+	// DomainTunableBlkdevReadBytesSecMaxLength as defined in libvirt/libvirt-domain.h:4307
 	DomainTunableBlkdevReadBytesSecMaxLength = "blkdeviotune.read_bytes_sec_max_length"
-	// DomainTunableBlkdevWriteBytesSecMaxLength as defined in libvirt/libvirt-domain.h:4260
+	// DomainTunableBlkdevWriteBytesSecMaxLength as defined in libvirt/libvirt-domain.h:4316
 	DomainTunableBlkdevWriteBytesSecMaxLength = "blkdeviotune.write_bytes_sec_max_length"
-	// DomainTunableBlkdevTotalIopsSecMaxLength as defined in libvirt/libvirt-domain.h:4269
+	// DomainTunableBlkdevTotalIopsSecMaxLength as defined in libvirt/libvirt-domain.h:4325
 	DomainTunableBlkdevTotalIopsSecMaxLength = "blkdeviotune.total_iops_sec_max_length"
-	// DomainTunableBlkdevReadIopsSecMaxLength as defined in libvirt/libvirt-domain.h:4278
+	// DomainTunableBlkdevReadIopsSecMaxLength as defined in libvirt/libvirt-domain.h:4334
 	DomainTunableBlkdevReadIopsSecMaxLength = "blkdeviotune.read_iops_sec_max_length"
-	// DomainTunableBlkdevWriteIopsSecMaxLength as defined in libvirt/libvirt-domain.h:4287
+	// DomainTunableBlkdevWriteIopsSecMaxLength as defined in libvirt/libvirt-domain.h:4343
 	DomainTunableBlkdevWriteIopsSecMaxLength = "blkdeviotune.write_iops_sec_max_length"
-	// DomainSchedFieldLength as defined in libvirt/libvirt-domain.h:4575
+	// DomainSchedFieldLength as defined in libvirt/libvirt-domain.h:4631
 	DomainSchedFieldLength = 80
-	// DomainBlkioFieldLength as defined in libvirt/libvirt-domain.h:4619
+	// DomainBlkioFieldLength as defined in libvirt/libvirt-domain.h:4675
 	DomainBlkioFieldLength = 80
-	// DomainMemoryFieldLength as defined in libvirt/libvirt-domain.h:4663
+	// DomainMemoryFieldLength as defined in libvirt/libvirt-domain.h:4719
 	DomainMemoryFieldLength = 80
-	// DomainLaunchSecuritySevMeasurement as defined in libvirt/libvirt-domain.h:4789
+	// DomainLaunchSecuritySevMeasurement as defined in libvirt/libvirt-domain.h:4845
 	DomainLaunchSecuritySevMeasurement = "sev-measurement"
 )
 
-// ConnectCloseReason as declared in libvirt/libvirt-common.h:120
+// ConnectCloseReason as declared in libvirt/libvirt-common.h:119
 type ConnectCloseReason int32
 
-// ConnectCloseReason enumeration from libvirt/libvirt-common.h:120
+// ConnectCloseReason enumeration from libvirt/libvirt-common.h:119
 const (
 	ConnectCloseReasonError     ConnectCloseReason = iota
 	ConnectCloseReasonEOF       ConnectCloseReason = 1
@@ -450,10 +458,10 @@ const (
 	ConnectCloseReasonClient    ConnectCloseReason = 3
 )
 
-// TypedParameterType as declared in libvirt/libvirt-common.h:139
+// TypedParameterType as declared in libvirt/libvirt-common.h:138
 type TypedParameterType int32
 
-// TypedParameterType enumeration from libvirt/libvirt-common.h:139
+// TypedParameterType enumeration from libvirt/libvirt-common.h:138
 const (
 	TypedParamInt     TypedParameterType = 1
 	TypedParamUint    TypedParameterType = 2
@@ -464,53 +472,53 @@ const (
 	TypedParamString  TypedParameterType = 7
 )
 
-// TypedParameterFlags as declared in libvirt/libvirt-common.h:164
+// TypedParameterFlags as declared in libvirt/libvirt-common.h:163
 type TypedParameterFlags int32
 
-// TypedParameterFlags enumeration from libvirt/libvirt-common.h:164
+// TypedParameterFlags enumeration from libvirt/libvirt-common.h:163
 const (
 	TypedParamStringOkay TypedParameterFlags = 4
 )
 
-// NodeSuspendTarget as declared in libvirt/libvirt-host.h:62
+// NodeSuspendTarget as declared in libvirt/libvirt-host.h:61
 type NodeSuspendTarget int32
 
-// NodeSuspendTarget enumeration from libvirt/libvirt-host.h:62
+// NodeSuspendTarget enumeration from libvirt/libvirt-host.h:61
 const (
 	NodeSuspendTargetMem    NodeSuspendTarget = iota
 	NodeSuspendTargetDisk   NodeSuspendTarget = 1
 	NodeSuspendTargetHybrid NodeSuspendTarget = 2
 )
 
-// NodeGetCPUStatsAllCPUs as declared in libvirt/libvirt-host.h:186
+// NodeGetCPUStatsAllCPUs as declared in libvirt/libvirt-host.h:185
 type NodeGetCPUStatsAllCPUs int32
 
-// NodeGetCPUStatsAllCPUs enumeration from libvirt/libvirt-host.h:186
+// NodeGetCPUStatsAllCPUs enumeration from libvirt/libvirt-host.h:185
 const (
 	NodeCPUStatsAllCpus NodeGetCPUStatsAllCPUs = -1
 )
 
-// NodeGetMemoryStatsAllCells as declared in libvirt/libvirt-host.h:264
+// NodeGetMemoryStatsAllCells as declared in libvirt/libvirt-host.h:263
 type NodeGetMemoryStatsAllCells int32
 
-// NodeGetMemoryStatsAllCells enumeration from libvirt/libvirt-host.h:264
+// NodeGetMemoryStatsAllCells enumeration from libvirt/libvirt-host.h:263
 const (
 	NodeMemoryStatsAllCells NodeGetMemoryStatsAllCells = -1
 )
 
-// ConnectFlags as declared in libvirt/libvirt-host.h:485
+// ConnectFlags as declared in libvirt/libvirt-host.h:484
 type ConnectFlags int32
 
-// ConnectFlags enumeration from libvirt/libvirt-host.h:485
+// ConnectFlags enumeration from libvirt/libvirt-host.h:484
 const (
 	ConnectRo        ConnectFlags = 1
 	ConnectNoAliases ConnectFlags = 2
 )
 
-// ConnectCredentialType as declared in libvirt/libvirt-host.h:502
+// ConnectCredentialType as declared in libvirt/libvirt-host.h:501
 type ConnectCredentialType int32
 
-// ConnectCredentialType enumeration from libvirt/libvirt-host.h:502
+// ConnectCredentialType enumeration from libvirt/libvirt-host.h:501
 const (
 	CredUsername     ConnectCredentialType = 1
 	CredAuthname     ConnectCredentialType = 2
@@ -523,10 +531,10 @@ const (
 	CredExternal     ConnectCredentialType = 9
 )
 
-// CPUCompareResult as declared in libvirt/libvirt-host.h:675
+// CPUCompareResult as declared in libvirt/libvirt-host.h:674
 type CPUCompareResult int32
 
-// CPUCompareResult enumeration from libvirt/libvirt-host.h:675
+// CPUCompareResult enumeration from libvirt/libvirt-host.h:674
 const (
 	CPUCompareError        CPUCompareResult = -1
 	CPUCompareIncompatible CPUCompareResult = 0
@@ -534,36 +542,36 @@ const (
 	CPUCompareSuperset     CPUCompareResult = 2
 )
 
-// ConnectCompareCPUFlags as declared in libvirt/libvirt-host.h:680
+// ConnectCompareCPUFlags as declared in libvirt/libvirt-host.h:679
 type ConnectCompareCPUFlags int32
 
-// ConnectCompareCPUFlags enumeration from libvirt/libvirt-host.h:680
+// ConnectCompareCPUFlags enumeration from libvirt/libvirt-host.h:679
 const (
 	ConnectCompareCPUFailIncompatible ConnectCompareCPUFlags = 1
 )
 
-// ConnectBaselineCPUFlags as declared in libvirt/libvirt-host.h:706
+// ConnectBaselineCPUFlags as declared in libvirt/libvirt-host.h:705
 type ConnectBaselineCPUFlags int32
 
-// ConnectBaselineCPUFlags enumeration from libvirt/libvirt-host.h:706
+// ConnectBaselineCPUFlags enumeration from libvirt/libvirt-host.h:705
 const (
 	ConnectBaselineCPUExpandFeatures ConnectBaselineCPUFlags = 1
 	ConnectBaselineCPUMigratable     ConnectBaselineCPUFlags = 2
 )
 
-// NodeAllocPagesFlags as declared in libvirt/libvirt-host.h:736
+// NodeAllocPagesFlags as declared in libvirt/libvirt-host.h:735
 type NodeAllocPagesFlags int32
 
-// NodeAllocPagesFlags enumeration from libvirt/libvirt-host.h:736
+// NodeAllocPagesFlags enumeration from libvirt/libvirt-host.h:735
 const (
 	NodeAllocPagesAdd NodeAllocPagesFlags = iota
 	NodeAllocPagesSet NodeAllocPagesFlags = 1
 )
 
-// DomainState as declared in libvirt/libvirt-domain.h:71
+// DomainState as declared in libvirt/libvirt-domain.h:70
 type DomainState int32
 
-// DomainState enumeration from libvirt/libvirt-domain.h:71
+// DomainState enumeration from libvirt/libvirt-domain.h:70
 const (
 	DomainNostate     DomainState = iota
 	DomainRunning     DomainState = 1
@@ -575,18 +583,18 @@ const (
 	DomainPmsuspended DomainState = 7
 )
 
-// DomainNostateReason as declared in libvirt/libvirt-domain.h:79
+// DomainNostateReason as declared in libvirt/libvirt-domain.h:78
 type DomainNostateReason int32
 
-// DomainNostateReason enumeration from libvirt/libvirt-domain.h:79
+// DomainNostateReason enumeration from libvirt/libvirt-domain.h:78
 const (
 	DomainNostateUnknown DomainNostateReason = iota
 )
 
-// DomainRunningReason as declared in libvirt/libvirt-domain.h:98
+// DomainRunningReason as declared in libvirt/libvirt-domain.h:97
 type DomainRunningReason int32
 
-// DomainRunningReason enumeration from libvirt/libvirt-domain.h:98
+// DomainRunningReason enumeration from libvirt/libvirt-domain.h:97
 const (
 	DomainRunningUnknown           DomainRunningReason = iota
 	DomainRunningBooted            DomainRunningReason = 1
@@ -601,18 +609,18 @@ const (
 	DomainRunningPostcopy          DomainRunningReason = 10
 )
 
-// DomainBlockedReason as declared in libvirt/libvirt-domain.h:106
+// DomainBlockedReason as declared in libvirt/libvirt-domain.h:105
 type DomainBlockedReason int32
 
-// DomainBlockedReason enumeration from libvirt/libvirt-domain.h:106
+// DomainBlockedReason enumeration from libvirt/libvirt-domain.h:105
 const (
 	DomainBlockedUnknown DomainBlockedReason = iota
 )
 
-// DomainPausedReason as declared in libvirt/libvirt-domain.h:127
+// DomainPausedReason as declared in libvirt/libvirt-domain.h:126
 type DomainPausedReason int32
 
-// DomainPausedReason enumeration from libvirt/libvirt-domain.h:127
+// DomainPausedReason enumeration from libvirt/libvirt-domain.h:126
 const (
 	DomainPausedUnknown        DomainPausedReason = iota
 	DomainPausedUser           DomainPausedReason = 1
@@ -630,19 +638,19 @@ const (
 	DomainPausedPostcopyFailed DomainPausedReason = 13
 )
 
-// DomainShutdownReason as declared in libvirt/libvirt-domain.h:136
+// DomainShutdownReason as declared in libvirt/libvirt-domain.h:135
 type DomainShutdownReason int32
 
-// DomainShutdownReason enumeration from libvirt/libvirt-domain.h:136
+// DomainShutdownReason enumeration from libvirt/libvirt-domain.h:135
 const (
 	DomainShutdownUnknown DomainShutdownReason = iota
 	DomainShutdownUser    DomainShutdownReason = 1
 )
 
-// DomainShutoffReason as declared in libvirt/libvirt-domain.h:151
+// DomainShutoffReason as declared in libvirt/libvirt-domain.h:152
 type DomainShutoffReason int32
 
-// DomainShutoffReason enumeration from libvirt/libvirt-domain.h:151
+// DomainShutoffReason enumeration from libvirt/libvirt-domain.h:152
 const (
 	DomainShutoffUnknown      DomainShutoffReason = iota
 	DomainShutoffShutdown     DomainShutoffReason = 1
@@ -652,37 +660,38 @@ const (
 	DomainShutoffSaved        DomainShutoffReason = 5
 	DomainShutoffFailed       DomainShutoffReason = 6
 	DomainShutoffFromSnapshot DomainShutoffReason = 7
+	DomainShutoffDaemon       DomainShutoffReason = 8
 )
 
-// DomainCrashedReason as declared in libvirt/libvirt-domain.h:160
+// DomainCrashedReason as declared in libvirt/libvirt-domain.h:161
 type DomainCrashedReason int32
 
-// DomainCrashedReason enumeration from libvirt/libvirt-domain.h:160
+// DomainCrashedReason enumeration from libvirt/libvirt-domain.h:161
 const (
 	DomainCrashedUnknown  DomainCrashedReason = iota
 	DomainCrashedPanicked DomainCrashedReason = 1
 )
 
-// DomainPMSuspendedReason as declared in libvirt/libvirt-domain.h:168
+// DomainPMSuspendedReason as declared in libvirt/libvirt-domain.h:169
 type DomainPMSuspendedReason int32
 
-// DomainPMSuspendedReason enumeration from libvirt/libvirt-domain.h:168
+// DomainPMSuspendedReason enumeration from libvirt/libvirt-domain.h:169
 const (
 	DomainPmsuspendedUnknown DomainPMSuspendedReason = iota
 )
 
-// DomainPMSuspendedDiskReason as declared in libvirt/libvirt-domain.h:176
+// DomainPMSuspendedDiskReason as declared in libvirt/libvirt-domain.h:177
 type DomainPMSuspendedDiskReason int32
 
-// DomainPMSuspendedDiskReason enumeration from libvirt/libvirt-domain.h:176
+// DomainPMSuspendedDiskReason enumeration from libvirt/libvirt-domain.h:177
 const (
 	DomainPmsuspendedDiskUnknown DomainPMSuspendedDiskReason = iota
 )
 
-// DomainControlState as declared in libvirt/libvirt-domain.h:196
+// DomainControlState as declared in libvirt/libvirt-domain.h:197
 type DomainControlState int32
 
-// DomainControlState enumeration from libvirt/libvirt-domain.h:196
+// DomainControlState enumeration from libvirt/libvirt-domain.h:197
 const (
 	DomainControlOk       DomainControlState = iota
 	DomainControlJob      DomainControlState = 1
@@ -690,10 +699,10 @@ const (
 	DomainControlError    DomainControlState = 3
 )
 
-// DomainControlErrorReason as declared in libvirt/libvirt-domain.h:216
+// DomainControlErrorReason as declared in libvirt/libvirt-domain.h:217
 type DomainControlErrorReason int32
 
-// DomainControlErrorReason enumeration from libvirt/libvirt-domain.h:216
+// DomainControlErrorReason enumeration from libvirt/libvirt-domain.h:217
 const (
 	DomainControlErrorReasonNone     DomainControlErrorReason = iota
 	DomainControlErrorReasonUnknown  DomainControlErrorReason = 1
@@ -701,20 +710,20 @@ const (
 	DomainControlErrorReasonInternal DomainControlErrorReason = 3
 )
 
-// DomainModificationImpact as declared in libvirt/libvirt-domain.h:264
+// DomainModificationImpact as declared in libvirt/libvirt-domain.h:265
 type DomainModificationImpact int32
 
-// DomainModificationImpact enumeration from libvirt/libvirt-domain.h:264
+// DomainModificationImpact enumeration from libvirt/libvirt-domain.h:265
 const (
 	DomainAffectCurrent DomainModificationImpact = iota
 	DomainAffectLive    DomainModificationImpact = 1
 	DomainAffectConfig  DomainModificationImpact = 2
 )
 
-// DomainCreateFlags as declared in libvirt/libvirt-domain.h:304
+// DomainCreateFlags as declared in libvirt/libvirt-domain.h:305
 type DomainCreateFlags int32
 
-// DomainCreateFlags enumeration from libvirt/libvirt-domain.h:304
+// DomainCreateFlags enumeration from libvirt/libvirt-domain.h:305
 const (
 	DomainNone             DomainCreateFlags = iota
 	DomainStartPaused      DomainCreateFlags = 1
@@ -724,10 +733,10 @@ const (
 	DomainStartValidate    DomainCreateFlags = 16
 )
 
-// DomainMemoryStatTags as declared in libvirt/libvirt-domain.h:647
+// DomainMemoryStatTags as declared in libvirt/libvirt-domain.h:648
 type DomainMemoryStatTags int32
 
-// DomainMemoryStatTags enumeration from libvirt/libvirt-domain.h:647
+// DomainMemoryStatTags enumeration from libvirt/libvirt-domain.h:648
 const (
 	DomainMemoryStatSwapIn        DomainMemoryStatTags = iota
 	DomainMemoryStatSwapOut       DomainMemoryStatTags = 1
@@ -743,10 +752,10 @@ const (
 	DomainMemoryStatNr            DomainMemoryStatTags = 11
 )
 
-// DomainCoreDumpFlags as declared in libvirt/libvirt-domain.h:666
+// DomainCoreDumpFlags as declared in libvirt/libvirt-domain.h:667
 type DomainCoreDumpFlags int32
 
-// DomainCoreDumpFlags enumeration from libvirt/libvirt-domain.h:666
+// DomainCoreDumpFlags enumeration from libvirt/libvirt-domain.h:667
 const (
 	DumpCrash       DomainCoreDumpFlags = 1
 	DumpLive        DomainCoreDumpFlags = 2
@@ -755,10 +764,10 @@ const (
 	DumpMemoryOnly  DomainCoreDumpFlags = 16
 )
 
-// DomainCoreDumpFormat as declared in libvirt/libvirt-domain.h:689
+// DomainCoreDumpFormat as declared in libvirt/libvirt-domain.h:690
 type DomainCoreDumpFormat int32
 
-// DomainCoreDumpFormat enumeration from libvirt/libvirt-domain.h:689
+// DomainCoreDumpFormat enumeration from libvirt/libvirt-domain.h:690
 const (
 	DomainCoreDumpFormatRaw         DomainCoreDumpFormat = iota
 	DomainCoreDumpFormatKdumpZlib   DomainCoreDumpFormat = 1
@@ -766,10 +775,10 @@ const (
 	DomainCoreDumpFormatKdumpSnappy DomainCoreDumpFormat = 3
 )
 
-// DomainMigrateFlags as declared in libvirt/libvirt-domain.h:833
+// DomainMigrateFlags as declared in libvirt/libvirt-domain.h:834
 type DomainMigrateFlags int32
 
-// DomainMigrateFlags enumeration from libvirt/libvirt-domain.h:833
+// DomainMigrateFlags enumeration from libvirt/libvirt-domain.h:834
 const (
 	MigrateLive             DomainMigrateFlags = 1
 	MigratePeer2peer        DomainMigrateFlags = 2
@@ -790,10 +799,10 @@ const (
 	MigrateTLS              DomainMigrateFlags = 65536
 )
 
-// DomainShutdownFlagValues as declared in libvirt/libvirt-domain.h:1128
+// DomainShutdownFlagValues as declared in libvirt/libvirt-domain.h:1129
 type DomainShutdownFlagValues int32
 
-// DomainShutdownFlagValues enumeration from libvirt/libvirt-domain.h:1128
+// DomainShutdownFlagValues enumeration from libvirt/libvirt-domain.h:1129
 const (
 	DomainShutdownDefault      DomainShutdownFlagValues = iota
 	DomainShutdownAcpiPowerBtn DomainShutdownFlagValues = 1
@@ -803,10 +812,10 @@ const (
 	DomainShutdownParavirt     DomainShutdownFlagValues = 16
 )
 
-// DomainRebootFlagValues as declared in libvirt/libvirt-domain.h:1141
+// DomainRebootFlagValues as declared in libvirt/libvirt-domain.h:1142
 type DomainRebootFlagValues int32
 
-// DomainRebootFlagValues enumeration from libvirt/libvirt-domain.h:1141
+// DomainRebootFlagValues enumeration from libvirt/libvirt-domain.h:1142
 const (
 	DomainRebootDefault      DomainRebootFlagValues = iota
 	DomainRebootAcpiPowerBtn DomainRebootFlagValues = 1
@@ -816,29 +825,29 @@ const (
 	DomainRebootParavirt     DomainRebootFlagValues = 16
 )
 
-// DomainDestroyFlagsValues as declared in libvirt/libvirt-domain.h:1159
+// DomainDestroyFlagsValues as declared in libvirt/libvirt-domain.h:1160
 type DomainDestroyFlagsValues int32
 
-// DomainDestroyFlagsValues enumeration from libvirt/libvirt-domain.h:1159
+// DomainDestroyFlagsValues enumeration from libvirt/libvirt-domain.h:1160
 const (
 	DomainDestroyDefault  DomainDestroyFlagsValues = iota
 	DomainDestroyGraceful DomainDestroyFlagsValues = 1
 )
 
-// DomainSaveRestoreFlags as declared in libvirt/libvirt-domain.h:1191
+// DomainSaveRestoreFlags as declared in libvirt/libvirt-domain.h:1192
 type DomainSaveRestoreFlags int32
 
-// DomainSaveRestoreFlags enumeration from libvirt/libvirt-domain.h:1191
+// DomainSaveRestoreFlags enumeration from libvirt/libvirt-domain.h:1192
 const (
 	DomainSaveBypassCache DomainSaveRestoreFlags = 1
 	DomainSaveRunning     DomainSaveRestoreFlags = 2
 	DomainSavePaused      DomainSaveRestoreFlags = 4
 )
 
-// DomainMemoryModFlags as declared in libvirt/libvirt-domain.h:1446
+// DomainMemoryModFlags as declared in libvirt/libvirt-domain.h:1447
 type DomainMemoryModFlags int32
 
-// DomainMemoryModFlags enumeration from libvirt/libvirt-domain.h:1446
+// DomainMemoryModFlags enumeration from libvirt/libvirt-domain.h:1447
 const (
 	DomainMemCurrent DomainMemoryModFlags = iota
 	DomainMemLive    DomainMemoryModFlags = 1
@@ -846,30 +855,30 @@ const (
 	DomainMemMaximum DomainMemoryModFlags = 4
 )
 
-// DomainNumatuneMemMode as declared in libvirt/libvirt-domain.h:1464
+// DomainNumatuneMemMode as declared in libvirt/libvirt-domain.h:1465
 type DomainNumatuneMemMode int32
 
-// DomainNumatuneMemMode enumeration from libvirt/libvirt-domain.h:1464
+// DomainNumatuneMemMode enumeration from libvirt/libvirt-domain.h:1465
 const (
 	DomainNumatuneMemStrict     DomainNumatuneMemMode = iota
 	DomainNumatuneMemPreferred  DomainNumatuneMemMode = 1
 	DomainNumatuneMemInterleave DomainNumatuneMemMode = 2
 )
 
-// DomainMetadataType as declared in libvirt/libvirt-domain.h:1526
+// DomainMetadataType as declared in libvirt/libvirt-domain.h:1527
 type DomainMetadataType int32
 
-// DomainMetadataType enumeration from libvirt/libvirt-domain.h:1526
+// DomainMetadataType enumeration from libvirt/libvirt-domain.h:1527
 const (
 	DomainMetadataDescription DomainMetadataType = iota
 	DomainMetadataTitle       DomainMetadataType = 1
 	DomainMetadataElement     DomainMetadataType = 2
 )
 
-// DomainXMLFlags as declared in libvirt/libvirt-domain.h:1556
+// DomainXMLFlags as declared in libvirt/libvirt-domain.h:1557
 type DomainXMLFlags int32
 
-// DomainXMLFlags enumeration from libvirt/libvirt-domain.h:1556
+// DomainXMLFlags enumeration from libvirt/libvirt-domain.h:1557
 const (
 	DomainXMLSecure     DomainXMLFlags = 1
 	DomainXMLInactive   DomainXMLFlags = 2
@@ -877,35 +886,35 @@ const (
 	DomainXMLMigratable DomainXMLFlags = 8
 )
 
-// DomainBlockResizeFlags as declared in libvirt/libvirt-domain.h:1661
+// DomainBlockResizeFlags as declared in libvirt/libvirt-domain.h:1662
 type DomainBlockResizeFlags int32
 
-// DomainBlockResizeFlags enumeration from libvirt/libvirt-domain.h:1661
+// DomainBlockResizeFlags enumeration from libvirt/libvirt-domain.h:1662
 const (
 	DomainBlockResizeBytes DomainBlockResizeFlags = 1
 )
 
-// DomainMemoryFlags as declared in libvirt/libvirt-domain.h:1724
+// DomainMemoryFlags as declared in libvirt/libvirt-domain.h:1725
 type DomainMemoryFlags int32
 
-// DomainMemoryFlags enumeration from libvirt/libvirt-domain.h:1724
+// DomainMemoryFlags enumeration from libvirt/libvirt-domain.h:1725
 const (
 	MemoryVirtual  DomainMemoryFlags = 1
 	MemoryPhysical DomainMemoryFlags = 2
 )
 
-// DomainDefineFlags as declared in libvirt/libvirt-domain.h:1734
+// DomainDefineFlags as declared in libvirt/libvirt-domain.h:1735
 type DomainDefineFlags int32
 
-// DomainDefineFlags enumeration from libvirt/libvirt-domain.h:1734
+// DomainDefineFlags enumeration from libvirt/libvirt-domain.h:1735
 const (
 	DomainDefineValidate DomainDefineFlags = 1
 )
 
-// DomainUndefineFlagsValues as declared in libvirt/libvirt-domain.h:1758
+// DomainUndefineFlagsValues as declared in libvirt/libvirt-domain.h:1759
 type DomainUndefineFlagsValues int32
 
-// DomainUndefineFlagsValues enumeration from libvirt/libvirt-domain.h:1758
+// DomainUndefineFlagsValues enumeration from libvirt/libvirt-domain.h:1759
 const (
 	DomainUndefineManagedSave       DomainUndefineFlagsValues = 1
 	DomainUndefineSnapshotsMetadata DomainUndefineFlagsValues = 2
@@ -913,10 +922,10 @@ const (
 	DomainUndefineKeepNvram         DomainUndefineFlagsValues = 8
 )
 
-// ConnectListAllDomainsFlags as declared in libvirt/libvirt-domain.h:1794
+// ConnectListAllDomainsFlags as declared in libvirt/libvirt-domain.h:1795
 type ConnectListAllDomainsFlags int32
 
-// ConnectListAllDomainsFlags enumeration from libvirt/libvirt-domain.h:1794
+// ConnectListAllDomainsFlags enumeration from libvirt/libvirt-domain.h:1795
 const (
 	ConnectListDomainsActive        ConnectListAllDomainsFlags = 1
 	ConnectListDomainsInactive      ConnectListAllDomainsFlags = 2
@@ -934,20 +943,20 @@ const (
 	ConnectListDomainsNoSnapshot    ConnectListAllDomainsFlags = 8192
 )
 
-// VCPUState as declared in libvirt/libvirt-domain.h:1825
+// VCPUState as declared in libvirt/libvirt-domain.h:1826
 type VCPUState int32
 
-// VCPUState enumeration from libvirt/libvirt-domain.h:1825
+// VCPUState enumeration from libvirt/libvirt-domain.h:1826
 const (
 	VCPUOffline VCPUState = iota
 	VCPURunning VCPUState = 1
 	VCPUBlocked VCPUState = 2
 )
 
-// DomainVCPUFlags as declared in libvirt/libvirt-domain.h:1847
+// DomainVCPUFlags as declared in libvirt/libvirt-domain.h:1848
 type DomainVCPUFlags int32
 
-// DomainVCPUFlags enumeration from libvirt/libvirt-domain.h:1847
+// DomainVCPUFlags enumeration from libvirt/libvirt-domain.h:1848
 const (
 	DomainVCPUCurrent      DomainVCPUFlags = iota
 	DomainVCPULive         DomainVCPUFlags = 1
@@ -957,10 +966,10 @@ const (
 	DomainVCPUHotpluggable DomainVCPUFlags = 16
 )
 
-// DomainDeviceModifyFlags as declared in libvirt/libvirt-domain.h:2020
+// DomainDeviceModifyFlags as declared in libvirt/libvirt-domain.h:2065
 type DomainDeviceModifyFlags int32
 
-// DomainDeviceModifyFlags enumeration from libvirt/libvirt-domain.h:2020
+// DomainDeviceModifyFlags enumeration from libvirt/libvirt-domain.h:2065
 const (
 	DomainDeviceModifyCurrent DomainDeviceModifyFlags = iota
 	DomainDeviceModifyLive    DomainDeviceModifyFlags = 1
@@ -968,10 +977,10 @@ const (
 	DomainDeviceModifyForce   DomainDeviceModifyFlags = 4
 )
 
-// DomainStatsTypes as declared in libvirt/libvirt-domain.h:2051
+// DomainStatsTypes as declared in libvirt/libvirt-domain.h:2097
 type DomainStatsTypes int32
 
-// DomainStatsTypes enumeration from libvirt/libvirt-domain.h:2051
+// DomainStatsTypes enumeration from libvirt/libvirt-domain.h:2097
 const (
 	DomainStatsState     DomainStatsTypes = 1
 	DomainStatsCPUTotal  DomainStatsTypes = 2
@@ -980,12 +989,13 @@ const (
 	DomainStatsInterface DomainStatsTypes = 16
 	DomainStatsBlock     DomainStatsTypes = 32
 	DomainStatsPerf      DomainStatsTypes = 64
+	DomainStatsIothread  DomainStatsTypes = 128
 )
 
-// ConnectGetAllDomainStatsFlags as declared in libvirt/libvirt-domain.h:2069
+// ConnectGetAllDomainStatsFlags as declared in libvirt/libvirt-domain.h:2115
 type ConnectGetAllDomainStatsFlags int32
 
-// ConnectGetAllDomainStatsFlags enumeration from libvirt/libvirt-domain.h:2069
+// ConnectGetAllDomainStatsFlags enumeration from libvirt/libvirt-domain.h:2115
 const (
 	ConnectGetAllDomainsStatsActive       ConnectGetAllDomainStatsFlags = 1
 	ConnectGetAllDomainsStatsInactive     ConnectGetAllDomainStatsFlags = 2
@@ -1000,10 +1010,10 @@ const (
 	ConnectGetAllDomainsStatsEnforceStats ConnectGetAllDomainStatsFlags = -2147483648
 )
 
-// DomainBlockJobType as declared in libvirt/libvirt-domain.h:2353
+// DomainBlockJobType as declared in libvirt/libvirt-domain.h:2399
 type DomainBlockJobType int32
 
-// DomainBlockJobType enumeration from libvirt/libvirt-domain.h:2353
+// DomainBlockJobType enumeration from libvirt/libvirt-domain.h:2399
 const (
 	DomainBlockJobTypeUnknown      DomainBlockJobType = iota
 	DomainBlockJobTypePull         DomainBlockJobType = 1
@@ -1012,43 +1022,43 @@ const (
 	DomainBlockJobTypeActiveCommit DomainBlockJobType = 4
 )
 
-// DomainBlockJobAbortFlags as declared in libvirt/libvirt-domain.h:2365
+// DomainBlockJobAbortFlags as declared in libvirt/libvirt-domain.h:2411
 type DomainBlockJobAbortFlags int32
 
-// DomainBlockJobAbortFlags enumeration from libvirt/libvirt-domain.h:2365
+// DomainBlockJobAbortFlags enumeration from libvirt/libvirt-domain.h:2411
 const (
 	DomainBlockJobAbortAsync DomainBlockJobAbortFlags = 1
 	DomainBlockJobAbortPivot DomainBlockJobAbortFlags = 2
 )
 
-// DomainBlockJobInfoFlags as declared in libvirt/libvirt-domain.h:2374
+// DomainBlockJobInfoFlags as declared in libvirt/libvirt-domain.h:2420
 type DomainBlockJobInfoFlags int32
 
-// DomainBlockJobInfoFlags enumeration from libvirt/libvirt-domain.h:2374
+// DomainBlockJobInfoFlags enumeration from libvirt/libvirt-domain.h:2420
 const (
 	DomainBlockJobInfoBandwidthBytes DomainBlockJobInfoFlags = 1
 )
 
-// DomainBlockJobSetSpeedFlags as declared in libvirt/libvirt-domain.h:2403
+// DomainBlockJobSetSpeedFlags as declared in libvirt/libvirt-domain.h:2449
 type DomainBlockJobSetSpeedFlags int32
 
-// DomainBlockJobSetSpeedFlags enumeration from libvirt/libvirt-domain.h:2403
+// DomainBlockJobSetSpeedFlags enumeration from libvirt/libvirt-domain.h:2449
 const (
 	DomainBlockJobSpeedBandwidthBytes DomainBlockJobSetSpeedFlags = 1
 )
 
-// DomainBlockPullFlags as declared in libvirt/libvirt-domain.h:2413
+// DomainBlockPullFlags as declared in libvirt/libvirt-domain.h:2459
 type DomainBlockPullFlags int32
 
-// DomainBlockPullFlags enumeration from libvirt/libvirt-domain.h:2413
+// DomainBlockPullFlags enumeration from libvirt/libvirt-domain.h:2459
 const (
 	DomainBlockPullBandwidthBytes DomainBlockPullFlags = 64
 )
 
-// DomainBlockRebaseFlags as declared in libvirt/libvirt-domain.h:2437
+// DomainBlockRebaseFlags as declared in libvirt/libvirt-domain.h:2483
 type DomainBlockRebaseFlags int32
 
-// DomainBlockRebaseFlags enumeration from libvirt/libvirt-domain.h:2437
+// DomainBlockRebaseFlags enumeration from libvirt/libvirt-domain.h:2483
 const (
 	DomainBlockRebaseShallow        DomainBlockRebaseFlags = 1
 	DomainBlockRebaseReuseExt       DomainBlockRebaseFlags = 2
@@ -1059,20 +1069,20 @@ const (
 	DomainBlockRebaseBandwidthBytes DomainBlockRebaseFlags = 64
 )
 
-// DomainBlockCopyFlags as declared in libvirt/libvirt-domain.h:2456
+// DomainBlockCopyFlags as declared in libvirt/libvirt-domain.h:2502
 type DomainBlockCopyFlags int32
 
-// DomainBlockCopyFlags enumeration from libvirt/libvirt-domain.h:2456
+// DomainBlockCopyFlags enumeration from libvirt/libvirt-domain.h:2502
 const (
 	DomainBlockCopyShallow      DomainBlockCopyFlags = 1
 	DomainBlockCopyReuseExt     DomainBlockCopyFlags = 2
 	DomainBlockCopyTransientJob DomainBlockCopyFlags = 4
 )
 
-// DomainBlockCommitFlags as declared in libvirt/libvirt-domain.h:2521
+// DomainBlockCommitFlags as declared in libvirt/libvirt-domain.h:2567
 type DomainBlockCommitFlags int32
 
-// DomainBlockCommitFlags enumeration from libvirt/libvirt-domain.h:2521
+// DomainBlockCommitFlags enumeration from libvirt/libvirt-domain.h:2567
 const (
 	DomainBlockCommitShallow        DomainBlockCommitFlags = 1
 	DomainBlockCommitDelete         DomainBlockCommitFlags = 2
@@ -1081,20 +1091,20 @@ const (
 	DomainBlockCommitBandwidthBytes DomainBlockCommitFlags = 16
 )
 
-// DomainDiskErrorCode as declared in libvirt/libvirt-domain.h:2712
+// DomainDiskErrorCode as declared in libvirt/libvirt-domain.h:2758
 type DomainDiskErrorCode int32
 
-// DomainDiskErrorCode enumeration from libvirt/libvirt-domain.h:2712
+// DomainDiskErrorCode enumeration from libvirt/libvirt-domain.h:2758
 const (
 	DomainDiskErrorNone    DomainDiskErrorCode = iota
 	DomainDiskErrorUnspec  DomainDiskErrorCode = 1
 	DomainDiskErrorNoSpace DomainDiskErrorCode = 2
 )
 
-// KeycodeSet as declared in libvirt/libvirt-domain.h:2758
+// KeycodeSet as declared in libvirt/libvirt-domain.h:2804
 type KeycodeSet int32
 
-// KeycodeSet enumeration from libvirt/libvirt-domain.h:2758
+// KeycodeSet enumeration from libvirt/libvirt-domain.h:2804
 const (
 	KeycodeSetLinux  KeycodeSet = iota
 	KeycodeSetXt     KeycodeSet = 1
@@ -1108,10 +1118,10 @@ const (
 	KeycodeSetQnum   KeycodeSet = 9
 )
 
-// DomainProcessSignal as declared in libvirt/libvirt-domain.h:2867
+// DomainProcessSignal as declared in libvirt/libvirt-domain.h:2913
 type DomainProcessSignal int32
 
-// DomainProcessSignal enumeration from libvirt/libvirt-domain.h:2867
+// DomainProcessSignal enumeration from libvirt/libvirt-domain.h:2913
 const (
 	DomainProcessSignalNop    DomainProcessSignal = iota
 	DomainProcessSignalHup    DomainProcessSignal = 1
@@ -1180,10 +1190,10 @@ const (
 	DomainProcessSignalRt32   DomainProcessSignal = 64
 )
 
-// DomainEventType as declared in libvirt/libvirt-domain.h:2905
+// DomainEventType as declared in libvirt/libvirt-domain.h:2951
 type DomainEventType int32
 
-// DomainEventType enumeration from libvirt/libvirt-domain.h:2905
+// DomainEventType enumeration from libvirt/libvirt-domain.h:2951
 const (
 	DomainEventDefined     DomainEventType = iota
 	DomainEventUndefined   DomainEventType = 1
@@ -1196,10 +1206,10 @@ const (
 	DomainEventCrashed     DomainEventType = 8
 )
 
-// DomainEventDefinedDetailType as declared in libvirt/libvirt-domain.h:2921
+// DomainEventDefinedDetailType as declared in libvirt/libvirt-domain.h:2967
 type DomainEventDefinedDetailType int32
 
-// DomainEventDefinedDetailType enumeration from libvirt/libvirt-domain.h:2921
+// DomainEventDefinedDetailType enumeration from libvirt/libvirt-domain.h:2967
 const (
 	DomainEventDefinedAdded        DomainEventDefinedDetailType = iota
 	DomainEventDefinedUpdated      DomainEventDefinedDetailType = 1
@@ -1207,19 +1217,19 @@ const (
 	DomainEventDefinedFromSnapshot DomainEventDefinedDetailType = 3
 )
 
-// DomainEventUndefinedDetailType as declared in libvirt/libvirt-domain.h:2935
+// DomainEventUndefinedDetailType as declared in libvirt/libvirt-domain.h:2981
 type DomainEventUndefinedDetailType int32
 
-// DomainEventUndefinedDetailType enumeration from libvirt/libvirt-domain.h:2935
+// DomainEventUndefinedDetailType enumeration from libvirt/libvirt-domain.h:2981
 const (
 	DomainEventUndefinedRemoved DomainEventUndefinedDetailType = iota
 	DomainEventUndefinedRenamed DomainEventUndefinedDetailType = 1
 )
 
-// DomainEventStartedDetailType as declared in libvirt/libvirt-domain.h:2952
+// DomainEventStartedDetailType as declared in libvirt/libvirt-domain.h:2998
 type DomainEventStartedDetailType int32
 
-// DomainEventStartedDetailType enumeration from libvirt/libvirt-domain.h:2952
+// DomainEventStartedDetailType enumeration from libvirt/libvirt-domain.h:2998
 const (
 	DomainEventStartedBooted       DomainEventStartedDetailType = iota
 	DomainEventStartedMigrated     DomainEventStartedDetailType = 1
@@ -1228,10 +1238,10 @@ const (
 	DomainEventStartedWakeup       DomainEventStartedDetailType = 4
 )
 
-// DomainEventSuspendedDetailType as declared in libvirt/libvirt-domain.h:2973
+// DomainEventSuspendedDetailType as declared in libvirt/libvirt-domain.h:3019
 type DomainEventSuspendedDetailType int32
 
-// DomainEventSuspendedDetailType enumeration from libvirt/libvirt-domain.h:2973
+// DomainEventSuspendedDetailType enumeration from libvirt/libvirt-domain.h:3019
 const (
 	DomainEventSuspendedPaused         DomainEventSuspendedDetailType = iota
 	DomainEventSuspendedMigrated       DomainEventSuspendedDetailType = 1
@@ -1244,10 +1254,10 @@ const (
 	DomainEventSuspendedPostcopyFailed DomainEventSuspendedDetailType = 8
 )
 
-// DomainEventResumedDetailType as declared in libvirt/libvirt-domain.h:2990
+// DomainEventResumedDetailType as declared in libvirt/libvirt-domain.h:3036
 type DomainEventResumedDetailType int32
 
-// DomainEventResumedDetailType enumeration from libvirt/libvirt-domain.h:2990
+// DomainEventResumedDetailType enumeration from libvirt/libvirt-domain.h:3036
 const (
 	DomainEventResumedUnpaused     DomainEventResumedDetailType = iota
 	DomainEventResumedMigrated     DomainEventResumedDetailType = 1
@@ -1255,10 +1265,10 @@ const (
 	DomainEventResumedPostcopy     DomainEventResumedDetailType = 3
 )
 
-// DomainEventStoppedDetailType as declared in libvirt/libvirt-domain.h:3009
+// DomainEventStoppedDetailType as declared in libvirt/libvirt-domain.h:3055
 type DomainEventStoppedDetailType int32
 
-// DomainEventStoppedDetailType enumeration from libvirt/libvirt-domain.h:3009
+// DomainEventStoppedDetailType enumeration from libvirt/libvirt-domain.h:3055
 const (
 	DomainEventStoppedShutdown     DomainEventStoppedDetailType = iota
 	DomainEventStoppedDestroyed    DomainEventStoppedDetailType = 1
@@ -1269,37 +1279,37 @@ const (
 	DomainEventStoppedFromSnapshot DomainEventStoppedDetailType = 6
 )
 
-// DomainEventShutdownDetailType as declared in libvirt/libvirt-domain.h:3032
+// DomainEventShutdownDetailType as declared in libvirt/libvirt-domain.h:3078
 type DomainEventShutdownDetailType int32
 
-// DomainEventShutdownDetailType enumeration from libvirt/libvirt-domain.h:3032
+// DomainEventShutdownDetailType enumeration from libvirt/libvirt-domain.h:3078
 const (
 	DomainEventShutdownFinished DomainEventShutdownDetailType = iota
 	DomainEventShutdownGuest    DomainEventShutdownDetailType = 1
 	DomainEventShutdownHost     DomainEventShutdownDetailType = 2
 )
 
-// DomainEventPMSuspendedDetailType as declared in libvirt/libvirt-domain.h:3046
+// DomainEventPMSuspendedDetailType as declared in libvirt/libvirt-domain.h:3092
 type DomainEventPMSuspendedDetailType int32
 
-// DomainEventPMSuspendedDetailType enumeration from libvirt/libvirt-domain.h:3046
+// DomainEventPMSuspendedDetailType enumeration from libvirt/libvirt-domain.h:3092
 const (
 	DomainEventPmsuspendedMemory DomainEventPMSuspendedDetailType = iota
 	DomainEventPmsuspendedDisk   DomainEventPMSuspendedDetailType = 1
 )
 
-// DomainEventCrashedDetailType as declared in libvirt/libvirt-domain.h:3059
+// DomainEventCrashedDetailType as declared in libvirt/libvirt-domain.h:3105
 type DomainEventCrashedDetailType int32
 
-// DomainEventCrashedDetailType enumeration from libvirt/libvirt-domain.h:3059
+// DomainEventCrashedDetailType enumeration from libvirt/libvirt-domain.h:3105
 const (
 	DomainEventCrashedPanicked DomainEventCrashedDetailType = iota
 )
 
-// DomainJobType as declared in libvirt/libvirt-domain.h:3103
+// DomainJobType as declared in libvirt/libvirt-domain.h:3149
 type DomainJobType int32
 
-// DomainJobType enumeration from libvirt/libvirt-domain.h:3103
+// DomainJobType enumeration from libvirt/libvirt-domain.h:3149
 const (
 	DomainJobNone      DomainJobType = iota
 	DomainJobBounded   DomainJobType = 1
@@ -1309,18 +1319,18 @@ const (
 	DomainJobCancelled DomainJobType = 5
 )
 
-// DomainGetJobStatsFlags as declared in libvirt/libvirt-domain.h:3150
+// DomainGetJobStatsFlags as declared in libvirt/libvirt-domain.h:3196
 type DomainGetJobStatsFlags int32
 
-// DomainGetJobStatsFlags enumeration from libvirt/libvirt-domain.h:3150
+// DomainGetJobStatsFlags enumeration from libvirt/libvirt-domain.h:3196
 const (
 	DomainJobStatsCompleted DomainGetJobStatsFlags = 1
 )
 
-// DomainJobOperation as declared in libvirt/libvirt-domain.h:3175
+// DomainJobOperation as declared in libvirt/libvirt-domain.h:3221
 type DomainJobOperation int32
 
-// DomainJobOperation enumeration from libvirt/libvirt-domain.h:3175
+// DomainJobOperation enumeration from libvirt/libvirt-domain.h:3221
 const (
 	DomainJobOperationStrUnknown        DomainJobOperation = iota
 	DomainJobOperationStrStart          DomainJobOperation = 1
@@ -1333,10 +1343,10 @@ const (
 	DomainJobOperationStrDump           DomainJobOperation = 8
 )
 
-// DomainEventWatchdogAction as declared in libvirt/libvirt-domain.h:3519
+// DomainEventWatchdogAction as declared in libvirt/libvirt-domain.h:3575
 type DomainEventWatchdogAction int32
 
-// DomainEventWatchdogAction enumeration from libvirt/libvirt-domain.h:3519
+// DomainEventWatchdogAction enumeration from libvirt/libvirt-domain.h:3575
 const (
 	DomainEventWatchdogNone      DomainEventWatchdogAction = iota
 	DomainEventWatchdogPause     DomainEventWatchdogAction = 1
@@ -1347,40 +1357,40 @@ const (
 	DomainEventWatchdogInjectnmi DomainEventWatchdogAction = 6
 )
 
-// DomainEventIOErrorAction as declared in libvirt/libvirt-domain.h:3550
+// DomainEventIOErrorAction as declared in libvirt/libvirt-domain.h:3606
 type DomainEventIOErrorAction int32
 
-// DomainEventIOErrorAction enumeration from libvirt/libvirt-domain.h:3550
+// DomainEventIOErrorAction enumeration from libvirt/libvirt-domain.h:3606
 const (
 	DomainEventIoErrorNone   DomainEventIOErrorAction = iota
 	DomainEventIoErrorPause  DomainEventIOErrorAction = 1
 	DomainEventIoErrorReport DomainEventIOErrorAction = 2
 )
 
-// DomainEventGraphicsPhase as declared in libvirt/libvirt-domain.h:3613
+// DomainEventGraphicsPhase as declared in libvirt/libvirt-domain.h:3669
 type DomainEventGraphicsPhase int32
 
-// DomainEventGraphicsPhase enumeration from libvirt/libvirt-domain.h:3613
+// DomainEventGraphicsPhase enumeration from libvirt/libvirt-domain.h:3669
 const (
 	DomainEventGraphicsConnect    DomainEventGraphicsPhase = iota
 	DomainEventGraphicsInitialize DomainEventGraphicsPhase = 1
 	DomainEventGraphicsDisconnect DomainEventGraphicsPhase = 2
 )
 
-// DomainEventGraphicsAddressType as declared in libvirt/libvirt-domain.h:3628
+// DomainEventGraphicsAddressType as declared in libvirt/libvirt-domain.h:3684
 type DomainEventGraphicsAddressType int32
 
-// DomainEventGraphicsAddressType enumeration from libvirt/libvirt-domain.h:3628
+// DomainEventGraphicsAddressType enumeration from libvirt/libvirt-domain.h:3684
 const (
 	DomainEventGraphicsAddressIpv4 DomainEventGraphicsAddressType = iota
 	DomainEventGraphicsAddressIpv6 DomainEventGraphicsAddressType = 1
 	DomainEventGraphicsAddressUnix DomainEventGraphicsAddressType = 2
 )
 
-// ConnectDomainEventBlockJobStatus as declared in libvirt/libvirt-domain.h:3716
+// ConnectDomainEventBlockJobStatus as declared in libvirt/libvirt-domain.h:3772
 type ConnectDomainEventBlockJobStatus int32
 
-// ConnectDomainEventBlockJobStatus enumeration from libvirt/libvirt-domain.h:3716
+// ConnectDomainEventBlockJobStatus enumeration from libvirt/libvirt-domain.h:3772
 const (
 	DomainBlockJobCompleted ConnectDomainEventBlockJobStatus = iota
 	DomainBlockJobFailed    ConnectDomainEventBlockJobStatus = 1
@@ -1388,47 +1398,47 @@ const (
 	DomainBlockJobReady     ConnectDomainEventBlockJobStatus = 3
 )
 
-// ConnectDomainEventDiskChangeReason as declared in libvirt/libvirt-domain.h:3766
+// ConnectDomainEventDiskChangeReason as declared in libvirt/libvirt-domain.h:3822
 type ConnectDomainEventDiskChangeReason int32
 
-// ConnectDomainEventDiskChangeReason enumeration from libvirt/libvirt-domain.h:3766
+// ConnectDomainEventDiskChangeReason enumeration from libvirt/libvirt-domain.h:3822
 const (
 	DomainEventDiskChangeMissingOnStart ConnectDomainEventDiskChangeReason = iota
 	DomainEventDiskDropMissingOnStart   ConnectDomainEventDiskChangeReason = 1
 )
 
-// DomainEventTrayChangeReason as declared in libvirt/libvirt-domain.h:3807
+// DomainEventTrayChangeReason as declared in libvirt/libvirt-domain.h:3863
 type DomainEventTrayChangeReason int32
 
-// DomainEventTrayChangeReason enumeration from libvirt/libvirt-domain.h:3807
+// DomainEventTrayChangeReason enumeration from libvirt/libvirt-domain.h:3863
 const (
 	DomainEventTrayChangeOpen  DomainEventTrayChangeReason = iota
 	DomainEventTrayChangeClose DomainEventTrayChangeReason = 1
 )
 
-// ConnectDomainEventAgentLifecycleState as declared in libvirt/libvirt-domain.h:4322
+// ConnectDomainEventAgentLifecycleState as declared in libvirt/libvirt-domain.h:4378
 type ConnectDomainEventAgentLifecycleState int32
 
-// ConnectDomainEventAgentLifecycleState enumeration from libvirt/libvirt-domain.h:4322
+// ConnectDomainEventAgentLifecycleState enumeration from libvirt/libvirt-domain.h:4378
 const (
 	ConnectDomainEventAgentLifecycleStateConnected    ConnectDomainEventAgentLifecycleState = 1
 	ConnectDomainEventAgentLifecycleStateDisconnected ConnectDomainEventAgentLifecycleState = 2
 )
 
-// ConnectDomainEventAgentLifecycleReason as declared in libvirt/libvirt-domain.h:4332
+// ConnectDomainEventAgentLifecycleReason as declared in libvirt/libvirt-domain.h:4388
 type ConnectDomainEventAgentLifecycleReason int32
 
-// ConnectDomainEventAgentLifecycleReason enumeration from libvirt/libvirt-domain.h:4332
+// ConnectDomainEventAgentLifecycleReason enumeration from libvirt/libvirt-domain.h:4388
 const (
 	ConnectDomainEventAgentLifecycleReasonUnknown       ConnectDomainEventAgentLifecycleReason = iota
 	ConnectDomainEventAgentLifecycleReasonDomainStarted ConnectDomainEventAgentLifecycleReason = 1
 	ConnectDomainEventAgentLifecycleReasonChannel       ConnectDomainEventAgentLifecycleReason = 2
 )
 
-// DomainEventID as declared in libvirt/libvirt-domain.h:4436
+// DomainEventID as declared in libvirt/libvirt-domain.h:4492
 type DomainEventID int32
 
-// DomainEventID enumeration from libvirt/libvirt-domain.h:4436
+// DomainEventID enumeration from libvirt/libvirt-domain.h:4492
 const (
 	DomainEventIDLifecycle           DomainEventID = iota
 	DomainEventIDReboot              DomainEventID = 1
@@ -1457,43 +1467,43 @@ const (
 	DomainEventIDBlockThreshold      DomainEventID = 24
 )
 
-// DomainConsoleFlags as declared in libvirt/libvirt-domain.h:4463
+// DomainConsoleFlags as declared in libvirt/libvirt-domain.h:4519
 type DomainConsoleFlags int32
 
-// DomainConsoleFlags enumeration from libvirt/libvirt-domain.h:4463
+// DomainConsoleFlags enumeration from libvirt/libvirt-domain.h:4519
 const (
 	DomainConsoleForce DomainConsoleFlags = 1
 	DomainConsoleSafe  DomainConsoleFlags = 2
 )
 
-// DomainChannelFlags as declared in libvirt/libvirt-domain.h:4479
+// DomainChannelFlags as declared in libvirt/libvirt-domain.h:4535
 type DomainChannelFlags int32
 
-// DomainChannelFlags enumeration from libvirt/libvirt-domain.h:4479
+// DomainChannelFlags enumeration from libvirt/libvirt-domain.h:4535
 const (
 	DomainChannelForce DomainChannelFlags = 1
 )
 
-// DomainOpenGraphicsFlags as declared in libvirt/libvirt-domain.h:4488
+// DomainOpenGraphicsFlags as declared in libvirt/libvirt-domain.h:4544
 type DomainOpenGraphicsFlags int32
 
-// DomainOpenGraphicsFlags enumeration from libvirt/libvirt-domain.h:4488
+// DomainOpenGraphicsFlags enumeration from libvirt/libvirt-domain.h:4544
 const (
 	DomainOpenGraphicsSkipauth DomainOpenGraphicsFlags = 1
 )
 
-// DomainSetTimeFlags as declared in libvirt/libvirt-domain.h:4545
+// DomainSetTimeFlags as declared in libvirt/libvirt-domain.h:4601
 type DomainSetTimeFlags int32
 
-// DomainSetTimeFlags enumeration from libvirt/libvirt-domain.h:4545
+// DomainSetTimeFlags enumeration from libvirt/libvirt-domain.h:4601
 const (
 	DomainTimeSync DomainSetTimeFlags = 1
 )
 
-// SchedParameterType as declared in libvirt/libvirt-domain.h:4566
+// SchedParameterType as declared in libvirt/libvirt-domain.h:4622
 type SchedParameterType int32
 
-// SchedParameterType enumeration from libvirt/libvirt-domain.h:4566
+// SchedParameterType enumeration from libvirt/libvirt-domain.h:4622
 const (
 	DomainSchedFieldInt     SchedParameterType = 1
 	DomainSchedFieldUint    SchedParameterType = 2
@@ -1503,10 +1513,10 @@ const (
 	DomainSchedFieldBoolean SchedParameterType = 6
 )
 
-// BlkioParameterType as declared in libvirt/libvirt-domain.h:4610
+// BlkioParameterType as declared in libvirt/libvirt-domain.h:4666
 type BlkioParameterType int32
 
-// BlkioParameterType enumeration from libvirt/libvirt-domain.h:4610
+// BlkioParameterType enumeration from libvirt/libvirt-domain.h:4666
 const (
 	DomainBlkioParamInt     BlkioParameterType = 1
 	DomainBlkioParamUint    BlkioParameterType = 2
@@ -1516,10 +1526,10 @@ const (
 	DomainBlkioParamBoolean BlkioParameterType = 6
 )
 
-// MemoryParameterType as declared in libvirt/libvirt-domain.h:4654
+// MemoryParameterType as declared in libvirt/libvirt-domain.h:4710
 type MemoryParameterType int32
 
-// MemoryParameterType enumeration from libvirt/libvirt-domain.h:4654
+// MemoryParameterType enumeration from libvirt/libvirt-domain.h:4710
 const (
 	DomainMemoryParamInt     MemoryParameterType = 1
 	DomainMemoryParamUint    MemoryParameterType = 2
@@ -1529,38 +1539,38 @@ const (
 	DomainMemoryParamBoolean MemoryParameterType = 6
 )
 
-// DomainInterfaceAddressesSource as declared in libvirt/libvirt-domain.h:4692
+// DomainInterfaceAddressesSource as declared in libvirt/libvirt-domain.h:4748
 type DomainInterfaceAddressesSource int32
 
-// DomainInterfaceAddressesSource enumeration from libvirt/libvirt-domain.h:4692
+// DomainInterfaceAddressesSource enumeration from libvirt/libvirt-domain.h:4748
 const (
 	DomainInterfaceAddressesSrcLease DomainInterfaceAddressesSource = iota
 	DomainInterfaceAddressesSrcAgent DomainInterfaceAddressesSource = 1
 	DomainInterfaceAddressesSrcArp   DomainInterfaceAddressesSource = 2
 )
 
-// DomainSetUserPasswordFlags as declared in libvirt/libvirt-domain.h:4720
+// DomainSetUserPasswordFlags as declared in libvirt/libvirt-domain.h:4776
 type DomainSetUserPasswordFlags int32
 
-// DomainSetUserPasswordFlags enumeration from libvirt/libvirt-domain.h:4720
+// DomainSetUserPasswordFlags enumeration from libvirt/libvirt-domain.h:4776
 const (
 	DomainPasswordEncrypted DomainSetUserPasswordFlags = 1
 )
 
-// DomainLifecycle as declared in libvirt/libvirt-domain.h:4759
+// DomainLifecycle as declared in libvirt/libvirt-domain.h:4815
 type DomainLifecycle int32
 
-// DomainLifecycle enumeration from libvirt/libvirt-domain.h:4759
+// DomainLifecycle enumeration from libvirt/libvirt-domain.h:4815
 const (
 	DomainLifecyclePoweroff DomainLifecycle = iota
 	DomainLifecycleReboot   DomainLifecycle = 1
 	DomainLifecycleCrash    DomainLifecycle = 2
 )
 
-// DomainLifecycleAction as declared in libvirt/libvirt-domain.h:4772
+// DomainLifecycleAction as declared in libvirt/libvirt-domain.h:4828
 type DomainLifecycleAction int32
 
-// DomainLifecycleAction enumeration from libvirt/libvirt-domain.h:4772
+// DomainLifecycleAction enumeration from libvirt/libvirt-domain.h:4828
 const (
 	DomainLifecycleActionDestroy         DomainLifecycleAction = iota
 	DomainLifecycleActionRestart         DomainLifecycleAction = 1
@@ -1570,10 +1580,10 @@ const (
 	DomainLifecycleActionCoredumpRestart DomainLifecycleAction = 5
 )
 
-// DomainSnapshotCreateFlags as declared in libvirt/libvirt-domain-snapshot.h:75
+// DomainSnapshotCreateFlags as declared in libvirt/libvirt-domain-snapshot.h:74
 type DomainSnapshotCreateFlags int32
 
-// DomainSnapshotCreateFlags enumeration from libvirt/libvirt-domain-snapshot.h:75
+// DomainSnapshotCreateFlags enumeration from libvirt/libvirt-domain-snapshot.h:74
 const (
 	DomainSnapshotCreateRedefine   DomainSnapshotCreateFlags = 1
 	DomainSnapshotCreateCurrent    DomainSnapshotCreateFlags = 2
@@ -1586,10 +1596,10 @@ const (
 	DomainSnapshotCreateLive       DomainSnapshotCreateFlags = 256
 )
 
-// DomainSnapshotListFlags as declared in libvirt/libvirt-domain-snapshot.h:135
+// DomainSnapshotListFlags as declared in libvirt/libvirt-domain-snapshot.h:134
 type DomainSnapshotListFlags int32
 
-// DomainSnapshotListFlags enumeration from libvirt/libvirt-domain-snapshot.h:135
+// DomainSnapshotListFlags enumeration from libvirt/libvirt-domain-snapshot.h:134
 const (
 	DomainSnapshotListRoots       DomainSnapshotListFlags = 1
 	DomainSnapshotListDescendants DomainSnapshotListFlags = 1
@@ -1604,30 +1614,30 @@ const (
 	DomainSnapshotListExternal    DomainSnapshotListFlags = 512
 )
 
-// DomainSnapshotRevertFlags as declared in libvirt/libvirt-domain-snapshot.h:192
+// DomainSnapshotRevertFlags as declared in libvirt/libvirt-domain-snapshot.h:191
 type DomainSnapshotRevertFlags int32
 
-// DomainSnapshotRevertFlags enumeration from libvirt/libvirt-domain-snapshot.h:192
+// DomainSnapshotRevertFlags enumeration from libvirt/libvirt-domain-snapshot.h:191
 const (
 	DomainSnapshotRevertRunning DomainSnapshotRevertFlags = 1
 	DomainSnapshotRevertPaused  DomainSnapshotRevertFlags = 2
 	DomainSnapshotRevertForce   DomainSnapshotRevertFlags = 4
 )
 
-// DomainSnapshotDeleteFlags as declared in libvirt/libvirt-domain-snapshot.h:206
+// DomainSnapshotDeleteFlags as declared in libvirt/libvirt-domain-snapshot.h:205
 type DomainSnapshotDeleteFlags int32
 
-// DomainSnapshotDeleteFlags enumeration from libvirt/libvirt-domain-snapshot.h:206
+// DomainSnapshotDeleteFlags enumeration from libvirt/libvirt-domain-snapshot.h:205
 const (
 	DomainSnapshotDeleteChildren     DomainSnapshotDeleteFlags = 1
 	DomainSnapshotDeleteMetadataOnly DomainSnapshotDeleteFlags = 2
 	DomainSnapshotDeleteChildrenOnly DomainSnapshotDeleteFlags = 4
 )
 
-// EventHandleType as declared in libvirt/libvirt-event.h:44
+// EventHandleType as declared in libvirt/libvirt-event.h:43
 type EventHandleType int32
 
-// EventHandleType enumeration from libvirt/libvirt-event.h:44
+// EventHandleType enumeration from libvirt/libvirt-event.h:43
 const (
 	EventHandleReadable EventHandleType = 1
 	EventHandleWritable EventHandleType = 2
@@ -1635,35 +1645,35 @@ const (
 	EventHandleHangup   EventHandleType = 8
 )
 
-// ConnectListAllInterfacesFlags as declared in libvirt/libvirt-interface.h:65
+// ConnectListAllInterfacesFlags as declared in libvirt/libvirt-interface.h:64
 type ConnectListAllInterfacesFlags int32
 
-// ConnectListAllInterfacesFlags enumeration from libvirt/libvirt-interface.h:65
+// ConnectListAllInterfacesFlags enumeration from libvirt/libvirt-interface.h:64
 const (
 	ConnectListInterfacesInactive ConnectListAllInterfacesFlags = 1
 	ConnectListInterfacesActive   ConnectListAllInterfacesFlags = 2
 )
 
-// InterfaceXMLFlags as declared in libvirt/libvirt-interface.h:81
+// InterfaceXMLFlags as declared in libvirt/libvirt-interface.h:80
 type InterfaceXMLFlags int32
 
-// InterfaceXMLFlags enumeration from libvirt/libvirt-interface.h:81
+// InterfaceXMLFlags enumeration from libvirt/libvirt-interface.h:80
 const (
 	InterfaceXMLInactive InterfaceXMLFlags = 1
 )
 
-// NetworkXMLFlags as declared in libvirt/libvirt-network.h:33
+// NetworkXMLFlags as declared in libvirt/libvirt-network.h:32
 type NetworkXMLFlags int32
 
-// NetworkXMLFlags enumeration from libvirt/libvirt-network.h:33
+// NetworkXMLFlags enumeration from libvirt/libvirt-network.h:32
 const (
 	NetworkXMLInactive NetworkXMLFlags = 1
 )
 
-// ConnectListAllNetworksFlags as declared in libvirt/libvirt-network.h:85
+// ConnectListAllNetworksFlags as declared in libvirt/libvirt-network.h:84
 type ConnectListAllNetworksFlags int32
 
-// ConnectListAllNetworksFlags enumeration from libvirt/libvirt-network.h:85
+// ConnectListAllNetworksFlags enumeration from libvirt/libvirt-network.h:84
 const (
 	ConnectListNetworksInactive    ConnectListAllNetworksFlags = 1
 	ConnectListNetworksActive      ConnectListAllNetworksFlags = 2
@@ -1673,10 +1683,10 @@ const (
 	ConnectListNetworksNoAutostart ConnectListAllNetworksFlags = 32
 )
 
-// NetworkUpdateCommand as declared in libvirt/libvirt-network.h:134
+// NetworkUpdateCommand as declared in libvirt/libvirt-network.h:133
 type NetworkUpdateCommand int32
 
-// NetworkUpdateCommand enumeration from libvirt/libvirt-network.h:134
+// NetworkUpdateCommand enumeration from libvirt/libvirt-network.h:133
 const (
 	NetworkUpdateCommandNone     NetworkUpdateCommand = iota
 	NetworkUpdateCommandModify   NetworkUpdateCommand = 1
@@ -1685,10 +1695,10 @@ const (
 	NetworkUpdateCommandAddFirst NetworkUpdateCommand = 4
 )
 
-// NetworkUpdateSection as declared in libvirt/libvirt-network.h:160
+// NetworkUpdateSection as declared in libvirt/libvirt-network.h:159
 type NetworkUpdateSection int32
 
-// NetworkUpdateSection enumeration from libvirt/libvirt-network.h:160
+// NetworkUpdateSection enumeration from libvirt/libvirt-network.h:159
 const (
 	NetworkSectionNone             NetworkUpdateSection = iota
 	NetworkSectionBridge           NetworkUpdateSection = 1
@@ -1705,20 +1715,20 @@ const (
 	NetworkSectionDNSSrv           NetworkUpdateSection = 12
 )
 
-// NetworkUpdateFlags as declared in libvirt/libvirt-network.h:172
+// NetworkUpdateFlags as declared in libvirt/libvirt-network.h:171
 type NetworkUpdateFlags int32
 
-// NetworkUpdateFlags enumeration from libvirt/libvirt-network.h:172
+// NetworkUpdateFlags enumeration from libvirt/libvirt-network.h:171
 const (
 	NetworkUpdateAffectCurrent NetworkUpdateFlags = iota
 	NetworkUpdateAffectLive    NetworkUpdateFlags = 1
 	NetworkUpdateAffectConfig  NetworkUpdateFlags = 2
 )
 
-// NetworkEventLifecycleType as declared in libvirt/libvirt-network.h:230
+// NetworkEventLifecycleType as declared in libvirt/libvirt-network.h:229
 type NetworkEventLifecycleType int32
 
-// NetworkEventLifecycleType enumeration from libvirt/libvirt-network.h:230
+// NetworkEventLifecycleType enumeration from libvirt/libvirt-network.h:229
 const (
 	NetworkEventDefined   NetworkEventLifecycleType = iota
 	NetworkEventUndefined NetworkEventLifecycleType = 1
@@ -1726,27 +1736,27 @@ const (
 	NetworkEventStopped   NetworkEventLifecycleType = 3
 )
 
-// NetworkEventID as declared in libvirt/libvirt-network.h:278
+// NetworkEventID as declared in libvirt/libvirt-network.h:277
 type NetworkEventID int32
 
-// NetworkEventID enumeration from libvirt/libvirt-network.h:278
+// NetworkEventID enumeration from libvirt/libvirt-network.h:277
 const (
 	NetworkEventIDLifecycle NetworkEventID = iota
 )
 
-// IPAddrType as declared in libvirt/libvirt-network.h:287
+// IPAddrType as declared in libvirt/libvirt-network.h:286
 type IPAddrType int32
 
-// IPAddrType enumeration from libvirt/libvirt-network.h:287
+// IPAddrType enumeration from libvirt/libvirt-network.h:286
 const (
 	IPAddrTypeIpv4 IPAddrType = iota
 	IPAddrTypeIpv6 IPAddrType = 1
 )
 
-// ConnectListAllNodeDeviceFlags as declared in libvirt/libvirt-nodedev.h:85
+// ConnectListAllNodeDeviceFlags as declared in libvirt/libvirt-nodedev.h:84
 type ConnectListAllNodeDeviceFlags int32
 
-// ConnectListAllNodeDeviceFlags enumeration from libvirt/libvirt-nodedev.h:85
+// ConnectListAllNodeDeviceFlags enumeration from libvirt/libvirt-nodedev.h:84
 const (
 	ConnectListNodeDevicesCapSystem       ConnectListAllNodeDeviceFlags = 1
 	ConnectListNodeDevicesCapPciDev       ConnectListAllNodeDeviceFlags = 2
@@ -1766,28 +1776,28 @@ const (
 	ConnectListNodeDevicesCapCcwDev       ConnectListAllNodeDeviceFlags = 32768
 )
 
-// NodeDeviceEventID as declared in libvirt/libvirt-nodedev.h:155
+// NodeDeviceEventID as declared in libvirt/libvirt-nodedev.h:154
 type NodeDeviceEventID int32
 
-// NodeDeviceEventID enumeration from libvirt/libvirt-nodedev.h:155
+// NodeDeviceEventID enumeration from libvirt/libvirt-nodedev.h:154
 const (
 	NodeDeviceEventIDLifecycle NodeDeviceEventID = iota
 	NodeDeviceEventIDUpdate    NodeDeviceEventID = 1
 )
 
-// NodeDeviceEventLifecycleType as declared in libvirt/libvirt-nodedev.h:197
+// NodeDeviceEventLifecycleType as declared in libvirt/libvirt-nodedev.h:196
 type NodeDeviceEventLifecycleType int32
 
-// NodeDeviceEventLifecycleType enumeration from libvirt/libvirt-nodedev.h:197
+// NodeDeviceEventLifecycleType enumeration from libvirt/libvirt-nodedev.h:196
 const (
 	NodeDeviceEventCreated NodeDeviceEventLifecycleType = iota
 	NodeDeviceEventDeleted NodeDeviceEventLifecycleType = 1
 )
 
-// SecretUsageType as declared in libvirt/libvirt-secret.h:56
+// SecretUsageType as declared in libvirt/libvirt-secret.h:55
 type SecretUsageType int32
 
-// SecretUsageType enumeration from libvirt/libvirt-secret.h:56
+// SecretUsageType enumeration from libvirt/libvirt-secret.h:55
 const (
 	SecretUsageTypeNone   SecretUsageType = iota
 	SecretUsageTypeVolume SecretUsageType = 1
@@ -1796,10 +1806,10 @@ const (
 	SecretUsageTypeTLS    SecretUsageType = 4
 )
 
-// ConnectListAllSecretsFlags as declared in libvirt/libvirt-secret.h:79
+// ConnectListAllSecretsFlags as declared in libvirt/libvirt-secret.h:78
 type ConnectListAllSecretsFlags int32
 
-// ConnectListAllSecretsFlags enumeration from libvirt/libvirt-secret.h:79
+// ConnectListAllSecretsFlags enumeration from libvirt/libvirt-secret.h:78
 const (
 	ConnectListSecretsEphemeral   ConnectListAllSecretsFlags = 1
 	ConnectListSecretsNoEphemeral ConnectListAllSecretsFlags = 2
@@ -1807,28 +1817,28 @@ const (
 	ConnectListSecretsNoPrivate   ConnectListAllSecretsFlags = 8
 )
 
-// SecretEventID as declared in libvirt/libvirt-secret.h:140
+// SecretEventID as declared in libvirt/libvirt-secret.h:139
 type SecretEventID int32
 
-// SecretEventID enumeration from libvirt/libvirt-secret.h:140
+// SecretEventID enumeration from libvirt/libvirt-secret.h:139
 const (
 	SecretEventIDLifecycle    SecretEventID = iota
 	SecretEventIDValueChanged SecretEventID = 1
 )
 
-// SecretEventLifecycleType as declared in libvirt/libvirt-secret.h:182
+// SecretEventLifecycleType as declared in libvirt/libvirt-secret.h:181
 type SecretEventLifecycleType int32
 
-// SecretEventLifecycleType enumeration from libvirt/libvirt-secret.h:182
+// SecretEventLifecycleType enumeration from libvirt/libvirt-secret.h:181
 const (
 	SecretEventDefined   SecretEventLifecycleType = iota
 	SecretEventUndefined SecretEventLifecycleType = 1
 )
 
-// StoragePoolState as declared in libvirt/libvirt-storage.h:58
+// StoragePoolState as declared in libvirt/libvirt-storage.h:57
 type StoragePoolState int32
 
-// StoragePoolState enumeration from libvirt/libvirt-storage.h:58
+// StoragePoolState enumeration from libvirt/libvirt-storage.h:57
 const (
 	StoragePoolInactive     StoragePoolState = iota
 	StoragePoolBuilding     StoragePoolState = 1
@@ -1837,10 +1847,10 @@ const (
 	StoragePoolInaccessible StoragePoolState = 4
 )
 
-// StoragePoolBuildFlags as declared in libvirt/libvirt-storage.h:66
+// StoragePoolBuildFlags as declared in libvirt/libvirt-storage.h:65
 type StoragePoolBuildFlags int32
 
-// StoragePoolBuildFlags enumeration from libvirt/libvirt-storage.h:66
+// StoragePoolBuildFlags enumeration from libvirt/libvirt-storage.h:65
 const (
 	StoragePoolBuildNew         StoragePoolBuildFlags = iota
 	StoragePoolBuildRepair      StoragePoolBuildFlags = 1
@@ -1849,19 +1859,19 @@ const (
 	StoragePoolBuildOverwrite   StoragePoolBuildFlags = 8
 )
 
-// StoragePoolDeleteFlags as declared in libvirt/libvirt-storage.h:71
+// StoragePoolDeleteFlags as declared in libvirt/libvirt-storage.h:70
 type StoragePoolDeleteFlags int32
 
-// StoragePoolDeleteFlags enumeration from libvirt/libvirt-storage.h:71
+// StoragePoolDeleteFlags enumeration from libvirt/libvirt-storage.h:70
 const (
 	StoragePoolDeleteNormal StoragePoolDeleteFlags = iota
 	StoragePoolDeleteZeroed StoragePoolDeleteFlags = 1
 )
 
-// StoragePoolCreateFlags as declared in libvirt/libvirt-storage.h:88
+// StoragePoolCreateFlags as declared in libvirt/libvirt-storage.h:87
 type StoragePoolCreateFlags int32
 
-// StoragePoolCreateFlags enumeration from libvirt/libvirt-storage.h:88
+// StoragePoolCreateFlags enumeration from libvirt/libvirt-storage.h:87
 const (
 	StoragePoolCreateNormal               StoragePoolCreateFlags = iota
 	StoragePoolCreateWithBuild            StoragePoolCreateFlags = 1
@@ -1869,10 +1879,10 @@ const (
 	StoragePoolCreateWithBuildNoOverwrite StoragePoolCreateFlags = 4
 )
 
-// StorageVolType as declared in libvirt/libvirt-storage.h:130
+// StorageVolType as declared in libvirt/libvirt-storage.h:129
 type StorageVolType int32
 
-// StorageVolType enumeration from libvirt/libvirt-storage.h:130
+// StorageVolType enumeration from libvirt/libvirt-storage.h:129
 const (
 	StorageVolFile    StorageVolType = iota
 	StorageVolBlock   StorageVolType = 1
@@ -1882,20 +1892,20 @@ const (
 	StorageVolPloop   StorageVolType = 5
 )
 
-// StorageVolDeleteFlags as declared in libvirt/libvirt-storage.h:136
+// StorageVolDeleteFlags as declared in libvirt/libvirt-storage.h:135
 type StorageVolDeleteFlags int32
 
-// StorageVolDeleteFlags enumeration from libvirt/libvirt-storage.h:136
+// StorageVolDeleteFlags enumeration from libvirt/libvirt-storage.h:135
 const (
 	StorageVolDeleteNormal        StorageVolDeleteFlags = iota
 	StorageVolDeleteZeroed        StorageVolDeleteFlags = 1
 	StorageVolDeleteWithSnapshots StorageVolDeleteFlags = 2
 )
 
-// StorageVolWipeAlgorithm as declared in libvirt/libvirt-storage.h:168
+// StorageVolWipeAlgorithm as declared in libvirt/libvirt-storage.h:167
 type StorageVolWipeAlgorithm int32
 
-// StorageVolWipeAlgorithm enumeration from libvirt/libvirt-storage.h:168
+// StorageVolWipeAlgorithm enumeration from libvirt/libvirt-storage.h:167
 const (
 	StorageVolWipeAlgZero       StorageVolWipeAlgorithm = iota
 	StorageVolWipeAlgNnsa       StorageVolWipeAlgorithm = 1
@@ -1909,27 +1919,27 @@ const (
 	StorageVolWipeAlgTrim       StorageVolWipeAlgorithm = 9
 )
 
-// StorageVolInfoFlags as declared in libvirt/libvirt-storage.h:176
+// StorageVolInfoFlags as declared in libvirt/libvirt-storage.h:175
 type StorageVolInfoFlags int32
 
-// StorageVolInfoFlags enumeration from libvirt/libvirt-storage.h:176
+// StorageVolInfoFlags enumeration from libvirt/libvirt-storage.h:175
 const (
 	StorageVolUseAllocation StorageVolInfoFlags = iota
 	StorageVolGetPhysical   StorageVolInfoFlags = 1
 )
 
-// StorageXMLFlags as declared in libvirt/libvirt-storage.h:190
+// StorageXMLFlags as declared in libvirt/libvirt-storage.h:189
 type StorageXMLFlags int32
 
-// StorageXMLFlags enumeration from libvirt/libvirt-storage.h:190
+// StorageXMLFlags enumeration from libvirt/libvirt-storage.h:189
 const (
 	StorageXMLInactive StorageXMLFlags = 1
 )
 
-// ConnectListAllStoragePoolsFlags as declared in libvirt/libvirt-storage.h:244
+// ConnectListAllStoragePoolsFlags as declared in libvirt/libvirt-storage.h:243
 type ConnectListAllStoragePoolsFlags int32
 
-// ConnectListAllStoragePoolsFlags enumeration from libvirt/libvirt-storage.h:244
+// ConnectListAllStoragePoolsFlags enumeration from libvirt/libvirt-storage.h:243
 const (
 	ConnectListStoragePoolsInactive    ConnectListAllStoragePoolsFlags = 1
 	ConnectListStoragePoolsActive      ConnectListAllStoragePoolsFlags = 2
@@ -1952,54 +1962,54 @@ const (
 	ConnectListStoragePoolsVstorage    ConnectListAllStoragePoolsFlags = 262144
 )
 
-// StorageVolCreateFlags as declared in libvirt/libvirt-storage.h:342
+// StorageVolCreateFlags as declared in libvirt/libvirt-storage.h:341
 type StorageVolCreateFlags int32
 
-// StorageVolCreateFlags enumeration from libvirt/libvirt-storage.h:342
+// StorageVolCreateFlags enumeration from libvirt/libvirt-storage.h:341
 const (
 	StorageVolCreatePreallocMetadata StorageVolCreateFlags = 1
 	StorageVolCreateReflink          StorageVolCreateFlags = 2
 )
 
-// StorageVolDownloadFlags as declared in libvirt/libvirt-storage.h:354
+// StorageVolDownloadFlags as declared in libvirt/libvirt-storage.h:353
 type StorageVolDownloadFlags int32
 
-// StorageVolDownloadFlags enumeration from libvirt/libvirt-storage.h:354
+// StorageVolDownloadFlags enumeration from libvirt/libvirt-storage.h:353
 const (
 	StorageVolDownloadSparseStream StorageVolDownloadFlags = 1
 )
 
-// StorageVolUploadFlags as declared in libvirt/libvirt-storage.h:363
+// StorageVolUploadFlags as declared in libvirt/libvirt-storage.h:362
 type StorageVolUploadFlags int32
 
-// StorageVolUploadFlags enumeration from libvirt/libvirt-storage.h:363
+// StorageVolUploadFlags enumeration from libvirt/libvirt-storage.h:362
 const (
 	StorageVolUploadSparseStream StorageVolUploadFlags = 1
 )
 
-// StorageVolResizeFlags as declared in libvirt/libvirt-storage.h:394
+// StorageVolResizeFlags as declared in libvirt/libvirt-storage.h:393
 type StorageVolResizeFlags int32
 
-// StorageVolResizeFlags enumeration from libvirt/libvirt-storage.h:394
+// StorageVolResizeFlags enumeration from libvirt/libvirt-storage.h:393
 const (
 	StorageVolResizeAllocate StorageVolResizeFlags = 1
 	StorageVolResizeDelta    StorageVolResizeFlags = 2
 	StorageVolResizeShrink   StorageVolResizeFlags = 4
 )
 
-// StoragePoolEventID as declared in libvirt/libvirt-storage.h:430
+// StoragePoolEventID as declared in libvirt/libvirt-storage.h:429
 type StoragePoolEventID int32
 
-// StoragePoolEventID enumeration from libvirt/libvirt-storage.h:430
+// StoragePoolEventID enumeration from libvirt/libvirt-storage.h:429
 const (
 	StoragePoolEventIDLifecycle StoragePoolEventID = iota
 	StoragePoolEventIDRefresh   StoragePoolEventID = 1
 )
 
-// StoragePoolEventLifecycleType as declared in libvirt/libvirt-storage.h:476
+// StoragePoolEventLifecycleType as declared in libvirt/libvirt-storage.h:475
 type StoragePoolEventLifecycleType int32
 
-// StoragePoolEventLifecycleType enumeration from libvirt/libvirt-storage.h:476
+// StoragePoolEventLifecycleType enumeration from libvirt/libvirt-storage.h:475
 const (
 	StoragePoolEventDefined   StoragePoolEventLifecycleType = iota
 	StoragePoolEventUndefined StoragePoolEventLifecycleType = 1
@@ -2009,26 +2019,26 @@ const (
 	StoragePoolEventDeleted   StoragePoolEventLifecycleType = 5
 )
 
-// StreamFlags as declared in libvirt/libvirt-stream.h:34
+// StreamFlags as declared in libvirt/libvirt-stream.h:33
 type StreamFlags int32
 
-// StreamFlags enumeration from libvirt/libvirt-stream.h:34
+// StreamFlags enumeration from libvirt/libvirt-stream.h:33
 const (
 	StreamNonblock StreamFlags = 1
 )
 
-// StreamRecvFlagsValues as declared in libvirt/libvirt-stream.h:50
+// StreamRecvFlagsValues as declared in libvirt/libvirt-stream.h:49
 type StreamRecvFlagsValues int32
 
-// StreamRecvFlagsValues enumeration from libvirt/libvirt-stream.h:50
+// StreamRecvFlagsValues enumeration from libvirt/libvirt-stream.h:49
 const (
 	StreamRecvStopAtHole StreamRecvFlagsValues = 1
 )
 
-// StreamEventType as declared in libvirt/libvirt-stream.h:238
+// StreamEventType as declared in libvirt/libvirt-stream.h:237
 type StreamEventType int32
 
-// StreamEventType enumeration from libvirt/libvirt-stream.h:238
+// StreamEventType enumeration from libvirt/libvirt-stream.h:237
 const (
 	StreamEventReadable StreamEventType = 1
 	StreamEventWritable StreamEventType = 2
@@ -2036,20 +2046,20 @@ const (
 	StreamEventHangup   StreamEventType = 8
 )
 
-// errorLevel as declared in libvirt/virterror.h:44
+// errorLevel as declared in libvirt/virterror.h:42
 type errorLevel int32
 
-// errorLevel enumeration from libvirt/virterror.h:44
+// errorLevel enumeration from libvirt/virterror.h:42
 const (
 	errNone    errorLevel = iota
 	errWarning errorLevel = 1
 	errError   errorLevel = 2
 )
 
-// errorDomain as declared in libvirt/virterror.h:140
+// errorDomain as declared in libvirt/virterror.h:139
 type errorDomain int32
 
-// errorDomain enumeration from libvirt/virterror.h:140
+// errorDomain enumeration from libvirt/virterror.h:139
 const (
 	fromNone           errorDomain = iota
 	fromXen            errorDomain = 1
@@ -2119,12 +2129,13 @@ const (
 	fromPerf           errorDomain = 65
 	fromLibssh         errorDomain = 66
 	fromResctrl        errorDomain = 67
+	fromFirewalld      errorDomain = 68
 )
 
-// errorNumber as declared in libvirt/virterror.h:326
+// errorNumber as declared in libvirt/virterror.h:330
 type errorNumber int32
 
-// errorNumber enumeration from libvirt/virterror.h:326
+// errorNumber enumeration from libvirt/virterror.h:330
 const (
 	errOk                     errorNumber = iota
 	errInternalError          errorNumber = 1

--- a/internal/constants/constants.gen.go
+++ b/internal/constants/constants.gen.go
@@ -864,6 +864,8 @@ const (
 	ProcNwfilterBindingDelete = 400
 	// ProcConnectListAllNwfilterBindings is libvirt's REMOTE_PROC_CONNECT_LIST_ALL_NWFILTER_BINDINGS
 	ProcConnectListAllNwfilterBindings = 401
+	// ProcDomainSetIothreadParams is libvirt's REMOTE_PROC_DOMAIN_SET_IOTHREAD_PARAMS
+	ProcDomainSetIothreadParams = 402
 
 
 	// From consts:
@@ -975,6 +977,8 @@ const (
 	DomainIPAddrMax = 2048
 	// DomainGuestVcpuParamsMax is libvirt's REMOTE_DOMAIN_GUEST_VCPU_PARAMS_MAX
 	DomainGuestVcpuParamsMax = 64
+	// DomainIothreadParamsMax is libvirt's REMOTE_DOMAIN_IOTHREAD_PARAMS_MAX
+	DomainIothreadParamsMax = 64
 	// NodeSevInfoMax is libvirt's REMOTE_NODE_SEV_INFO_MAX
 	NodeSevInfoMax = 64
 	// DomainLaunchSecurityInfoParamsMax is libvirt's REMOTE_DOMAIN_LAUNCH_SECURITY_INFO_PARAMS_MAX

--- a/internal/lvgen/procedures.tmpl
+++ b/internal/lvgen/procedures.tmpl
@@ -36,11 +36,11 @@ const (
 
 type typedParamDecoder struct {}
 
-// decodeTypedParam decodes a TypedParam. These are part of the libvirt spec,
-// and not xdr proper. TypedParams contain a name, which is called Field for
-// some reason, and a Value, which itself has a "discriminant" - an integer enum
-// encoding the actual type, and a value, the length of which varies based on
-// the actual type.
+// Decode decodes a TypedParam. These are part of the libvirt spec, and not xdr
+// proper. TypedParams contain a name, which is called Field for some reason,
+// and a Value, which itself has a "discriminant" - an integer enum encoding the
+// actual type, and a value, the length of which varies based on the actual
+// type.
 func (tpd typedParamDecoder) Decode(d *xdr.Decoder, v reflect.Value) (int, error) {
 	// Get the name of the typed param first
 	name, n, err := d.DecodeString()


### PR DESCRIPTION
- Regenerate the code using the latest release of libvirt (5.1)
- Fix a comment