### PR TITLE
Lifecycle events

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Alexander Polyakov <apolyakov@beget.com>
 Amanda Andrade <amanda.andrade@serpro.gov.br>
 Geoff Hickey <ghickey@digitalocean.com>
 Yuriy Taraday <yorik.sar@gmail.com>
+Sylvain Baubeau <sbaubeau@redhat.com>


### PR DESCRIPTION
This PR allows receiving lifecycle events by adding a `LifecycleEvents` method that returns a channel of events, similar to the `Events` method.

```
	events,` _ := l.LifecycleEvents()

	for event := range events {
		switch libvirt.DomainEventType(event.Event) {
		case libvirt.DomainEventStarted:
			log.Printf("Started domain %+v", event.Dom)
		case libvirt.DomainEventStopped:
			log.Printf("Stopped domain %+v", event.Dom)
		}
	}
```