### PR TITLE
Send data before handling errors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ Amanda Andrade <amanda.andrade@serpro.gov.br>
 Geoff Hickey <ghickey@digitalocean.com>
 Yuriy Taraday <yorik.sar@gmail.com>
 Sylvain Baubeau <sbaubeau@redhat.com>
+David Schneider <dsbrng25b@gmail.com>

--- a/rpc.go
+++ b/rpc.go
@@ -411,6 +411,12 @@ func (l *Libvirt) sendStream(serial uint32, proc uint32, program uint32, stream 
 		default:
 		}
 		n, err := stream.Read(buf)
+		if n > 0 {
+			err2 := l.sendPacket(serial, proc, program, buf[:n], Stream, StatusContinue)
+			if err2 != nil {
+				return err2
+			}
+		}
 		if err != nil {
 			if err == io.EOF {
 				return l.sendPacket(serial, proc, program, nil, Stream, StatusOK)
@@ -421,12 +427,6 @@ func (l *Libvirt) sendStream(serial uint32, proc uint32, program uint32, stream 
 				return err2
 			}
 			return err
-		}
-		if n > 0 {
-			err = l.sendPacket(serial, proc, program, buf[:n], Stream, StatusContinue)
-			if err != nil {
-				return err
-			}
 		}
 	}
 }


### PR DESCRIPTION
If Read receives some data together with io.EOF the data has to be sent before
sending StatusOK or StatusError which indicates the end of the stream.