### PR TITLE
Fix rpc.go crash (issue #85)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Geoff Hickey <ghickey@digitalocean.com>
 Yuriy Taraday <yorik.sar@gmail.com>
 Sylvain Baubeau <sbaubeau@redhat.com>
 David Schneider <dsbrng25b@gmail.com>
+Alec Hothan <ahothan@gmail.com>

--- a/rpc.go
+++ b/rpc.go
@@ -519,13 +519,10 @@ func eventDecoder(buf []byte, e interface{}) error {
 func pktlen(r io.Reader) (uint32, error) {
 	buf := make([]byte, constants.PacketLengthSize)
 
-	for n := 0; n < cap(buf); {
-		nn, err := r.Read(buf)
-		if err != nil {
-			return 0, err
-		}
-
-		n += nn
+	// read exactly constants.PacketLengthSize bytes
+	_, err := io.ReadFull(r, buf)
+	if err != nil {
+		return 0, err
 	}
 
 	return binary.BigEndian.Uint32(buf), nil
@@ -535,13 +532,10 @@ func pktlen(r io.Reader) (uint32, error) {
 func extractHeader(r io.Reader) (*header, error) {
 	buf := make([]byte, constants.HeaderSize)
 
-	for n := 0; n < cap(buf); {
-		nn, err := r.Read(buf)
-		if err != nil {
-			return nil, err
-		}
-
-		n += nn
+	// read exactly constants.HeaderSize bytes
+	_, err := io.ReadFull(r, buf)
+	if err != nil {
+		return nil, err
 	}
 
 	h := &header{


### PR DESCRIPTION
https://github.com/digitalocean/go-libvirt/issues/85

This patch fixes the occasional crash that happens in rpc.go.
The crash occurs when a reply is coming back fragmented and socket read returns an incomplete
length field or header field.
The original code is incorrect as the read loop writes at the start of the buffer at every iteration when it should write at the next position (passed the bytes already read).
ReadFull() will actually do just what is needed.

I have tested the patch and it fixes the crash (which could be reproduce very easily with prior code).
