### PR TITLE
Fix #96 Libvirt locks on getResponse()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,4 @@ Yuriy Taraday <yorik.sar@gmail.com>
 Sylvain Baubeau <sbaubeau@redhat.com>
 David Schneider <dsbrng25b@gmail.com>
 Alec Hothan <ahothan@gmail.com>
+Oleg Neumyvakin <oneumyvakin@gmail.com>


### PR DESCRIPTION
Fix for #96 which adding timeout in one minute for reading response.

It will be good if someone shed a light what is response time depends on.