### PR TITLE
fix deadlock by channel waitting 

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -194,12 +194,14 @@ func (l *Libvirt) callback(id uint32, res response) {
 	c, ok := l.callbacks[id]
 	l.cm.Unlock()
 	if ok {
-		// we close the channel in deregister() so that we don't block here
-		// forever without a receiver. If that happens, this write will panic.
-		defer func() {
-			recover()
+		go func() {
+			// we close the channel in deregister() so that we don't block here
+			// forever without a receiver. If that happens, this write will panic.
+			defer func() {
+				recover()
+			}()
+			c <- res
 		}()
-		c <- res
 	}
 }
 
@@ -245,12 +247,14 @@ func (l *Libvirt) stream(e event) error {
 	l.em.Unlock()
 
 	if ok {
-		// we close the channel in deregister() so that we don't block here
-		// forever without a receiver. If that happens, this write will panic.
-		defer func() {
-			recover()
+		go func() {
+			// we close the channel in deregister() so that we don't block here
+			// forever without a receiver. If that happens, this write will panic.
+			defer func() {
+				recover()
+			}()
+			c.Events <- e
 		}()
-		c.Events <- e
 	}
 	return nil
 }


### PR DESCRIPTION
This bug was due to channel waitting each other. 
Let's assume a function try to listen events on lifecycle events channel, at the same time, it also invokes   a function at following process, which looks like:
for event := range LifecycleEvents() {
   timeConsumingFunction()
    DomainGetVcpusFlags
}
It could cause deadlock, the root of deadlock is the route() function contains both event channel and callback channel process logic. If the for loop above pulls a event from event channel, and at the time of execution of  timeConsumingFunction, more event comes. Then the route() funtion will try send those new events via event channel. But nobody could recieve those events. However, at the same time when the DomainGetVcpusFlags function got to be executed, it also hang for route() function updating the callback channel. The sad thing is, route() function would never got there since it traps in waitting.
This is how the deadlock happens, and my pr could fix it by putting both event send code into goroutine.