### PR TITLE
Fix two race conditions related to Disconnect

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -149,10 +149,11 @@ func (l *Libvirt) Connect() error {
 }
 
 // Disconnect shuts down communication with the libvirt server and closes the
-// underlying net.Conn. Ordering is important here. We want to make sure the
-// connection is closed before unsubscribing and deregistering the events and
-// requests, to prevent new requests from racing.
+// underlying net.Conn.
 func (l *Libvirt) Disconnect() error {
+	// Ordering is important here. We want to make sure the connection is closed
+	// before unsubscribing and deregistering the events and requests, to
+	// prevent new requests from racing.
 	_, err := l.request(constants.ProcConnectClose, constants.Program, nil)
 	if err != nil {
 		return err

--- a/rpc.go
+++ b/rpc.go
@@ -243,19 +243,18 @@ func (l *Libvirt) addStream(s *event.Stream) {
 	l.events[s.CallbackID] = s
 }
 
-// removeStream notifies the libvirt server to stop sending events for the
-// provided callback ID. Upon successful de-registration the callback handler
-// is destroyed. Subsequent calls to removeStream are idempotent and return
-// nil.
-// TODO: Fix this comment
+// removeStream deletes an event stream. The caller should first notify libvirt
+// to stop sending events for this stream. Subsequent calls to removeStream are
+// idempotent and return nil.
 func (l *Libvirt) removeStream(id int32) error {
 	l.emux.Lock()
 	defer l.emux.Unlock()
 
 	// if the event is already removed, just return nil
-	_, ok := l.events[id]
+	q, ok := l.events[id]
 	if ok {
 		delete(l.events, id)
+		q.Shutdown()
 	}
 
 	return nil


### PR DESCRIPTION
* Because the Disconnect() implementation unsubscribed existing requests
before closing the connection to libvirt, it was possible for a new
request to be sent to libvirt in between the unsubscribe call and the
closing of the connection. Such a request would then be waiting for
responses on that closed connection, which is a quiet thing to do.

* Events had an unrelated problem, where the events channel never got
closed when the connection was closed, so they also ended up waiting
forever for a message that would never come.