### PR TITLE
Make libvirtError public so clients can use this

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -111,8 +111,8 @@ type response struct {
 	Status  uint32
 }
 
-// libvirt error response
-type libvirtError struct {
+// LibvirtError response
+type LibvirtError struct {
 	Code     uint32
 	DomainID uint32
 	Padding  uint8
@@ -120,15 +120,15 @@ type libvirtError struct {
 	Level    uint32
 }
 
-func (e libvirtError) Error() string {
+func (e LibvirtError) Error() string {
 	return e.Message
 }
 
-// checkError is used to check whether an error is a libvirtError, and if it is,
+// checkError is used to check whether an error is a LibvirtError, and if it is,
 // whether its error code matches the one passed in. It will return false if
 // these conditions are not met.
 func checkError(err error, expectedError errorNumber) bool {
-	e, ok := err.(libvirtError)
+	e, ok := err.(LibvirtError)
 	if ok {
 		return e.Code == uint32(expectedError)
 	}
@@ -472,7 +472,7 @@ func encode(data interface{}) ([]byte, error) {
 
 // decodeError extracts an error message from the provider buffer.
 func decodeError(buf []byte) error {
-	var e libvirtError
+	var e LibvirtError
 
 	dec := xdr.NewDecoder(bytes.NewReader(buf))
 	_, err := dec.Decode(&e)

--- a/rpc.go
+++ b/rpc.go
@@ -111,8 +111,8 @@ type response struct {
 	Status  uint32
 }
 
-// LibvirtError response
-type LibvirtError struct {
+// LvirtError response
+type LvirtError struct {
 	Code     uint32
 	DomainID uint32
 	Padding  uint8
@@ -120,15 +120,15 @@ type LibvirtError struct {
 	Level    uint32
 }
 
-func (e LibvirtError) Error() string {
+func (e LvirtError) Error() string {
 	return e.Message
 }
 
-// checkError is used to check whether an error is a LibvirtError, and if it is,
+// checkError is used to check whether an error is a LvirtError, and if it is,
 // whether its error code matches the one passed in. It will return false if
 // these conditions are not met.
 func checkError(err error, expectedError errorNumber) bool {
-	e, ok := err.(LibvirtError)
+	e, ok := err.(LvirtError)
 	if ok {
 		return e.Code == uint32(expectedError)
 	}
@@ -472,7 +472,7 @@ func encode(data interface{}) ([]byte, error) {
 
 // decodeError extracts an error message from the provider buffer.
 func decodeError(buf []byte) error {
-	var e LibvirtError
+	var e LvirtError
 
 	dec := xdr.NewDecoder(bytes.NewReader(buf))
 	_, err := dec.Decode(&e)

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -243,7 +243,7 @@ func TestDecodeError(t *testing.T) {
 	expectedCode := errOperationInvalid
 
 	err := decodeError(testErrorMessage)
-	e := err.(libvirtError)
+	e := err.(LibvirtError)
 	if e.Message != expectedMsg {
 		t.Errorf("expected error message %s, got %s", expectedMsg, err.Error())
 	}

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -243,7 +243,7 @@ func TestDecodeError(t *testing.T) {
 	expectedCode := errOperationInvalid
 
 	err := decodeError(testErrorMessage)
-	e := err.(LibvirtError)
+	e := err.(LvirtError)
 	if e.Message != expectedMsg {
 		t.Errorf("expected error message %s, got %s", expectedMsg, err.Error())
 	}


### PR DESCRIPTION
Closes #121 #56

Inspired by #57 

used by https://github.com/dmacvicar/terraform-provider-libvirt/pull/813