### PR TITLE
fix race in disconnect of event stream cleanup

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -627,9 +627,7 @@ func (l *Libvirt) listenAndRoute() {
 	l.listen()
 
 	// close event streams
-	for _, ev := range l.events {
-		l.unsubscribeEvents(ev)
-	}
+	l.removeAllStreams()
 
 	// Deregister all callbacks to prevent blocking on clients with
 	// outstanding requests

--- a/rpc.go
+++ b/rpc.go
@@ -273,6 +273,19 @@ func (l *Libvirt) removeStream(id int32) error {
 	return nil
 }
 
+// removeAllStreams deletes all event streams.  This is meant to be used to
+// clean up only once the underlying connection to libvirt is disconnected and
+// thus does not attempt to notify libvirt to stop sending events.
+func (l *Libvirt) removeAllStreams() {
+	l.emux.Lock()
+	defer l.emux.Unlock()
+
+	for _, ev := range l.events {
+		delete(l.events, ev.CallbackID)
+		ev.Shutdown()
+	}
+}
+
 // register configures a method response callback
 func (l *Libvirt) register(id int32, c chan response) {
 	l.cmux.Lock()

--- a/rpc.go
+++ b/rpc.go
@@ -281,8 +281,8 @@ func (l *Libvirt) removeAllStreams() {
 	defer l.emux.Unlock()
 
 	for _, ev := range l.events {
-		delete(l.events, ev.CallbackID)
 		ev.Shutdown()
+		delete(l.events, ev.CallbackID)
 	}
 }
 

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -347,6 +347,42 @@ func TestRemoveStream(t *testing.T) {
 	}
 }
 
+func TestRemoveAllStreams(t *testing.T) {
+	id1 := int32(1)
+	id2 := int32(2)
+
+	conn := libvirttest.New()
+	l := New(conn)
+
+	err := l.Connect()
+	if err != nil {
+		t.Fatalf("connect failed: %v", err)
+	}
+	defer l.Disconnect()
+
+	// verify it's a successful no-op when no streams have been added
+	l.removeAllStreams()
+	if len(l.events) != 0 {
+		t.Fatal("expected no streams after remove all")
+	}
+
+	stream := event.NewStream(constants.QEMUProgram, id1)
+	defer stream.Shutdown()
+
+	l.events[id1] = stream
+
+	stream2 := event.NewStream(constants.QEMUProgram, id2)
+	defer stream2.Shutdown()
+
+	l.events[id2] = stream2
+
+	l.removeAllStreams()
+
+	if len(l.events) != 0 {
+		t.Error("expected all event streams to be removed")
+	}
+}
+
 func TestStream(t *testing.T) {
 	id := int32(1)
 	stream := event.NewStream(constants.Program, 1)


### PR DESCRIPTION
I'm not sure whether this fixes the deadlock in unsubscribeEvents you mentioned previously @benlemasurier , but it does fix two things:
- the unsafe access of the events map without holding the mutex
- it doesn't attempt to send the message to libvirt to unsubscribe (because at the point this code is being hit, it means we detected the connection to libvirt is already gone)