### PR TITLE
add socket type to handle socket connection management

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -61,7 +61,7 @@ const (
 // Libvirt implements libvirt's remote procedure call protocol.
 type Libvirt struct {
 	// socket connection
-	socket socket.Socket
+	socket *socket.Socket
 	// closed after cleanup complete following the underlying connection to
 	// libvirt being disconnected.
 	disconnected chan struct{}

--- a/libvirt.go
+++ b/libvirt.go
@@ -19,7 +19,6 @@ package libvirt
 //go:generate scripts/gen-consts.sh
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -32,6 +31,7 @@ import (
 	"github.com/digitalocean/go-libvirt/internal/constants"
 	"github.com/digitalocean/go-libvirt/internal/event"
 	xdr "github.com/digitalocean/go-libvirt/internal/go-xdr/xdr2"
+	"github.com/digitalocean/go-libvirt/socket"
 )
 
 // ErrEventsNotSupported is returned by Events() if event streams
@@ -60,10 +60,8 @@ const (
 
 // Libvirt implements libvirt's remote procedure call protocol.
 type Libvirt struct {
-	conn net.Conn
-	r    *bufio.Reader
-	w    *bufio.Writer
-	mu   *sync.Mutex
+	// socket connection
+	socket socket.Socket
 	// closed after cleanup complete following the underlying connection to
 	// libvirt being disconnected.
 	disconnected chan struct{}
@@ -164,7 +162,10 @@ func (l *Libvirt) Disconnect() error {
 	if err != nil {
 		return err
 	}
-	err = l.conn.Close()
+	err = l.socket.Disconnect()
+	if err != nil {
+		return err
+	}
 
 	// wait for the listen goroutine to detect the lost connection and clean up
 	// to happen once it returns.  Safeguard with a timeout.
@@ -291,10 +292,10 @@ func (l *Libvirt) SubscribeEvents(ctx context.Context, eventID DomainEventID,
 
 // unsubscribeEvents stops the flow of the specified events from libvirt. There
 // are two steps to this process: a call to libvirt to deregister our callback,
-// and then removing the callback from the list used by the `route` function. If
+// and then removing the callback from the list used by the `Route` function. If
 // the deregister call fails, we'll return the error, but still remove the
 // callback from the list. That's ok; if any events arrive after this point, the
-// route function will drop them when it finds no registered handler.
+// Route function will drop them when it finds no registered handler.
 func (l *Libvirt) unsubscribeEvents(stream *event.Stream) error {
 	err := l.ConnectDomainEventCallbackDeregisterAny(stream.CallbackID)
 	l.removeStream(stream.CallbackID)
@@ -621,10 +622,9 @@ func getQEMUError(r response) error {
 	return nil
 }
 
-func (l *Libvirt) listenAndRoute() {
-	// only returns once it detects a non-temporary error related to the
-	// underlying connection
-	l.listen()
+func (l *Libvirt) waitAndDisconnect() {
+	// wait for the socket to indicate if/when it's been disconnected
+	<-l.socket.Disconnected()
 
 	// close event streams
 	for _, ev := range l.events {
@@ -641,17 +641,19 @@ func (l *Libvirt) listenAndRoute() {
 // New configures a new Libvirt RPC connection.
 func New(conn net.Conn) *Libvirt {
 	l := &Libvirt{
-		conn:         conn,
 		s:            0,
-		r:            bufio.NewReader(conn),
-		w:            bufio.NewWriter(conn),
-		mu:           &sync.Mutex{},
 		disconnected: make(chan struct{}),
 		callbacks:    make(map[int32]chan response),
 		events:       make(map[int32]*event.Stream),
 	}
 
-	go l.listenAndRoute()
+	// this starts the listening and routing
+	// TODO:  The connection and listen goroutine should be moved to the
+	//  Connect function, but this is going to impact the exported API, so
+	//  trying to do as much as possible before doing that.
+	l.socket = socket.New(conn, l)
+
+	go l.waitAndDisconnect()
 
 	return l
 }

--- a/rpc.go
+++ b/rpc.go
@@ -16,95 +16,21 @@ package libvirt
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"reflect"
 	"strings"
 	"sync/atomic"
-	"unsafe"
 
 	"github.com/digitalocean/go-libvirt/internal/constants"
 	"github.com/digitalocean/go-libvirt/internal/event"
 	xdr "github.com/digitalocean/go-libvirt/internal/go-xdr/xdr2"
+	"github.com/digitalocean/go-libvirt/socket"
 )
 
 // ErrUnsupported is returned if a procedure is not supported by libvirt
 var ErrUnsupported = errors.New("unsupported procedure requested")
-
-// request and response types
-const (
-	// Call is used when making calls to the remote server.
-	Call = iota
-
-	// Reply indicates a server reply.
-	Reply
-
-	// Message is an asynchronous notification.
-	Message
-
-	// Stream represents a stream data packet.
-	Stream
-
-	// CallWithFDs is used by a client to indicate the request has
-	// arguments with file descriptors.
-	CallWithFDs
-
-	// ReplyWithFDs is used by a server to indicate the request has
-	// arguments with file descriptors.
-	ReplyWithFDs
-)
-
-// request and response statuses
-const (
-	// StatusOK is always set for method calls or events.
-	// For replies it indicates successful completion of the method.
-	// For streams it indicates confirmation of the end of file on the stream.
-	StatusOK = iota
-
-	// StatusError for replies indicates that the method call failed
-	// and error information is being returned. For streams this indicates
-	// that not all data was sent and the stream has aborted.
-	StatusError
-
-	// StatusContinue is only used for streams.
-	// This indicates that further data packets will be following.
-	StatusContinue
-)
-
-// header is a libvirt rpc packet header
-type header struct {
-	// Program identifier
-	Program uint32
-
-	// Program version
-	Version uint32
-
-	// Remote procedure identifier
-	Procedure uint32
-
-	// Call type, e.g., Reply
-	Type uint32
-
-	// Call serial number
-	Serial int32
-
-	// Request status, e.g., StatusOK
-	Status uint32
-}
-
-// packet represents a RPC request or response.
-type packet struct {
-	// Size of packet, in bytes, including length.
-	// Len + Header + Payload
-	Len    uint32
-	Header header
-}
-
-// Global packet instance, for use with unsafe.Sizeof()
-var _p packet
 
 // internal rpc response
 type response struct {
@@ -141,56 +67,6 @@ func IsNotFound(err error) bool {
 	return checkError(err, ErrNoDomain)
 }
 
-// isTemporary returns true if the error returned from a read is transient.
-// If the error type is an OpError, check whether the net connection
-// error condition is temporary (which means we can keep using the
-// connection).
-// Errors not of the net.OpError type tend to be things like io.EOF,
-// syscall.EINVAL, or io.ErrClosedPipe (i.e. all things that
-// indicate the connection in use is no longer valid.)
-func isTemporary(err error) bool {
-	opErr, ok := err.(*net.OpError)
-	if ok {
-		return opErr.Temporary()
-	}
-	return false
-}
-
-// listen processes incoming data and routes
-// responses to their respective callback handler.
-func (l *Libvirt) listen() {
-	for {
-		// response packet length
-		length, err := pktlen(l.r)
-		if err != nil {
-			if isTemporary(err) {
-				continue
-			}
-			// connection is no longer valid, so shutdown
-			return
-		}
-
-		// response header
-		h, err := extractHeader(l.r)
-		if err != nil {
-			// invalid packet
-			continue
-		}
-
-		// payload: packet length minus what was previously read
-		size := int(length) - int(unsafe.Sizeof(_p))
-		buf := make([]byte, size)
-		_, err = io.ReadFull(l.r, buf)
-		if err != nil {
-			// invalid packet
-			continue
-		}
-
-		// route response to caller
-		l.route(h, buf)
-	}
-}
-
 // callback sends RPC responses to respective callers.
 func (l *Libvirt) callback(id int32, res response) {
 	l.cmux.Lock()
@@ -204,9 +80,9 @@ func (l *Libvirt) callback(id int32, res response) {
 	c <- res
 }
 
-// route sends incoming packets to their listeners.
-func (l *Libvirt) route(h *header, buf []byte) {
-	// route events to their respective listener
+// Route sends incoming packets to their listeners.
+func (l *Libvirt) Route(h *socket.Header, buf []byte) {
+	// Route events to their respective listener
 	var event event.Event
 
 	switch {
@@ -328,7 +204,8 @@ func (l *Libvirt) requestStream(proc uint32, program uint32, payload []byte,
 		l.deregister(serial)
 	}()
 
-	err := l.sendPacket(serial, proc, program, payload, Call, StatusOK)
+	err := l.socket.SendPacket(serial, proc, program, payload, socket.Call,
+		socket.StatusOK)
 	if err != nil {
 		return response{}, err
 	}
@@ -342,7 +219,7 @@ func (l *Libvirt) requestStream(proc uint32, program uint32, payload []byte,
 		abort := make(chan bool)
 		outErr := make(chan error)
 		go func() {
-			outErr <- l.sendStream(serial, proc, program, out, abort)
+			outErr <- l.socket.SendStream(serial, proc, program, out, abort)
 		}()
 
 		// Even without incoming stream server sends confirmation once all data is received
@@ -377,7 +254,7 @@ func (l *Libvirt) processIncomingStream(c chan response, inStream io.Writer) (re
 		}
 
 		// StatusOK indicates end of stream
-		if resp.Status == StatusOK {
+		if resp.Status == socket.StatusOK {
 			return resp, nil
 		}
 
@@ -398,77 +275,9 @@ func (l *Libvirt) processIncomingStream(c chan response, inStream io.Writer) (re
 	}
 }
 
-func (l *Libvirt) sendStream(serial int32, proc uint32, program uint32, stream io.Reader, abort chan bool) error {
-	// Keep total packet length under 4 MiB to follow possible limitation in libvirt server code
-	buf := make([]byte, 4*MiB-unsafe.Sizeof(_p))
-	for {
-		select {
-		case <-abort:
-			return l.sendPacket(serial, proc, program, nil, Stream, StatusError)
-		default:
-		}
-		n, err := stream.Read(buf)
-		if n > 0 {
-			err2 := l.sendPacket(serial, proc, program, buf[:n], Stream, StatusContinue)
-			if err2 != nil {
-				return err2
-			}
-		}
-		if err != nil {
-			if err == io.EOF {
-				return l.sendPacket(serial, proc, program, nil, Stream, StatusOK)
-			}
-			// keep original error
-			err2 := l.sendPacket(serial, proc, program, nil, Stream, StatusError)
-			if err2 != nil {
-				return err2
-			}
-			return err
-		}
-	}
-}
-
-func (l *Libvirt) sendPacket(serial int32, proc uint32, program uint32, payload []byte, typ uint32, status uint32) error {
-
-	p := packet{
-		Header: header{
-			Program:   program,
-			Version:   constants.ProtocolVersion,
-			Procedure: proc,
-			Type:      typ,
-			Serial:    serial,
-			Status:    status,
-		},
-	}
-
-	size := int(unsafe.Sizeof(p.Len)) + int(unsafe.Sizeof(p.Header))
-	if payload != nil {
-		size += len(payload)
-	}
-	p.Len = uint32(size)
-
-	// write header
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	err := binary.Write(l.w, binary.BigEndian, p)
-	if err != nil {
-		return err
-	}
-
-	// write payload
-	if payload != nil {
-		err = binary.Write(l.w, binary.BigEndian, payload)
-		if err != nil {
-			return err
-		}
-	}
-
-	return l.w.Flush()
-}
-
 func (l *Libvirt) getResponse(c chan response) (response, error) {
 	resp := <-c
-	if resp.Status == StatusError {
+	if resp.Status == socket.StatusError {
 		return resp, decodeError(resp.Payload)
 	}
 
@@ -516,40 +325,6 @@ func eventDecoder(buf []byte, e interface{}) error {
 	dec := xdr.NewDecoder(bytes.NewReader(buf))
 	_, err := dec.Decode(e)
 	return err
-}
-
-// pktlen returns the length of an incoming RPC packet.  Read errors will
-// result in a returned response length of 0 and a non-nil error.
-func pktlen(r io.Reader) (uint32, error) {
-	buf := make([]byte, unsafe.Sizeof(_p.Len))
-
-	// extract the packet's length from the header
-	_, err := io.ReadFull(r, buf)
-	if err != nil {
-		return 0, err
-	}
-
-	return binary.BigEndian.Uint32(buf), nil
-}
-
-// extractHeader returns the decoded header from an incoming response.
-func extractHeader(r io.Reader) (*header, error) {
-	buf := make([]byte, unsafe.Sizeof(_p.Header))
-
-	// extract the packet's header from r
-	_, err := io.ReadFull(r, buf)
-	if err != nil {
-		return nil, err
-	}
-
-	return &header{
-		Program:   binary.BigEndian.Uint32(buf[0:4]),
-		Version:   binary.BigEndian.Uint32(buf[4:8]),
-		Procedure: binary.BigEndian.Uint32(buf[8:12]),
-		Type:      binary.BigEndian.Uint32(buf[12:16]),
-		Serial:    int32(binary.BigEndian.Uint32(buf[16:20])),
-		Status:    binary.BigEndian.Uint32(buf[20:24]),
-	}, nil
 }
 
 type typedParamDecoder struct{}

--- a/socket/socket.go
+++ b/socket/socket.go
@@ -1,0 +1,359 @@
+package socket
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/digitalocean/go-libvirt/internal/constants"
+)
+
+const disconnectTimeout = 5*time.Second
+
+// request and response statuses
+const (
+	// StatusOK is always set for method calls or events.
+	// For replies it indicates successful completion of the method.
+	// For streams it indicates confirmation of the end of file on the stream.
+	StatusOK = iota
+
+	// StatusError for replies indicates that the method call failed
+	// and error information is being returned. For streams this indicates
+	// that not all data was sent and the stream has aborted.
+	StatusError
+
+	// StatusContinue is only used for streams.
+	// This indicates that further data packets will be following.
+	StatusContinue
+)
+
+// request and response types
+const (
+	// Call is used when making calls to the remote server.
+	Call = iota
+
+	// Reply indicates a server reply.
+	Reply
+
+	// Message is an asynchronous notification.
+	Message
+
+	// Stream represents a stream data packet.
+	Stream
+
+	// CallWithFDs is used by a client to indicate the request has
+	// arguments with file descriptors.
+	CallWithFDs
+
+	// ReplyWithFDs is used by a server to indicate the request has
+	// arguments with file descriptors.
+	ReplyWithFDs
+)
+
+// Router is an interface used to route packets to the appropriate clients.
+type Router interface {
+	Route(*Header, []byte)
+}
+
+// Socket represents a libvirt Socket and its connection state
+type Socket struct {
+	router Router
+
+	conn   net.Conn
+	reader *bufio.Reader
+	writer *bufio.Writer
+	// used to serialize any Socket writes and any updates to conn, r, or w
+	mu *sync.Mutex
+
+	// disconnected is closed when the listen goroutine associated with a
+	// Socket connection has returned.
+	disconnected chan struct{}
+}
+
+// packet represents a RPC request or response.
+type packet struct {
+	// Size of packet, in bytes, including length.
+	// Len + Header + Payload
+	Len    uint32
+	Header Header
+}
+
+// Global packet instance, for use with unsafe.Sizeof()
+var _p packet
+
+// Header is a libvirt rpc packet header
+type Header struct {
+	// Program identifier
+	Program uint32
+
+	// Program version
+	Version uint32
+
+	// Remote procedure identifier
+	Procedure uint32
+
+	// Call type, e.g., Reply
+	Type uint32
+
+	// Call serial number
+	Serial int32
+
+	// Request status, e.g., StatusOK
+	Status uint32
+}
+
+// New initializes a new type for managing the Socket.
+func New(conn net.Conn, router Router) Socket {
+	s := Socket{
+		router: router,
+		mu:     &sync.Mutex{},
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.conn = conn
+	s.reader = bufio.NewReader(conn)
+	s.writer = bufio.NewWriter(conn)
+	s.disconnected = make(chan struct{})
+
+	// TODO:  The connection and listen goroutine should be moved to the
+	//  Connect function, but this is going to impact the exported API, so
+	//  trying to do as much as possible before doing that.
+	go s.listenAndRoute()
+
+	return s
+}
+
+// Disconnect closes the Socket connection to libvirt and waits for the reader
+// gorouting to shut down.
+func (s Socket) Disconnect() error {
+	// just return if we're already disconnected
+	if s.isDisconnected() {
+		return nil
+	}
+
+	err := s.conn.Close()
+	if err != nil {
+		return err
+	}
+
+	// now we wait for the reader to return so as not to avoid it nil
+	// referencing
+	// Put this in a select,
+	// and have it only nil out the conn value if it doesn't fail
+	select {
+	case <-s.disconnected:
+	case <-time.After(disconnectTimeout):
+		return errors.New("timed out waiting for Disconnect cleanup")
+	}
+
+	return nil
+}
+
+// Disconnected returns a channel that will be closed once the current
+// connection is closed.  This can happen due to an explicit call to Disconnect
+// from the client, or due to non-temporary Read or Write errors encountered.
+func (s Socket) Disconnected() <-chan struct{} {
+	return s.disconnected
+}
+
+// isDisconnected is a non-blocking function to query whether a connection
+// is disconnected or not.
+func (s Socket) isDisconnected() bool {
+	select {
+	case <-s.disconnected:
+		return true
+	default:
+		return false
+	}
+}
+
+// listenAndRoute reads packets from the Socket and calls the provided
+// Router function to route them
+func (s Socket) listenAndRoute() {
+	// only returns once it detects a non-temporary error related to the
+	// underlying connection
+	listen(s.reader, s.router)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reader = nil
+	s.writer = nil
+	s.conn = nil
+
+	// signal any clients listening that the connection has been disconnected
+	close(s.disconnected)
+}
+
+// listen processes incoming data and routes
+// responses to their respective callback handler.
+func listen(s io.Reader, router Router) {
+	for {
+		// response packet length
+		length, err := pktlen(s)
+		if err != nil {
+			if isTemporary(err) {
+				continue
+			}
+			// connection is no longer valid, so shutdown
+			return
+		}
+
+		// response header
+		h, err := extractHeader(s)
+		if err != nil {
+			// invalid packet
+			continue
+		}
+
+		// payload: packet length minus what was previously read
+		size := int(length) - int(unsafe.Sizeof(_p))
+		buf := make([]byte, size)
+		_, err = io.ReadFull(s, buf)
+		if err != nil {
+			// invalid packet
+			continue
+		}
+
+		// route response to caller
+		router.Route(h, buf)
+	}
+}
+
+// isTemporary returns true if the error returned from a read is transient.
+// If the error type is an OpError, check whether the net connection
+// error condition is temporary (which means we can keep using the
+// connection).
+// Errors not of the net.OpError type tend to be things like io.EOF,
+// syscall.EINVAL, or io.ErrClosedPipe (i.e. all things that
+// indicate the connection in use is no longer valid.)
+func isTemporary(err error) bool {
+	opErr, ok := err.(*net.OpError)
+	if ok {
+		return opErr.Temporary()
+	}
+	return false
+}
+
+// pktlen returns the length of an incoming RPC packet.  Read errors will
+// result in a returned response length of 0 and a non-nil error.
+func pktlen(r io.Reader) (uint32, error) {
+	buf := make([]byte, unsafe.Sizeof(_p.Len))
+
+	// extract the packet's length from the header
+	_, err := io.ReadFull(r, buf)
+	if err != nil {
+		return 0, err
+	}
+
+	return binary.BigEndian.Uint32(buf), nil
+}
+
+// extractHeader returns the decoded header from an incoming response.
+func extractHeader(r io.Reader) (*Header, error) {
+	buf := make([]byte, unsafe.Sizeof(_p.Header))
+
+	// extract the packet's header from r
+	_, err := io.ReadFull(r, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Header{
+		Program:   binary.BigEndian.Uint32(buf[0:4]),
+		Version:   binary.BigEndian.Uint32(buf[4:8]),
+		Procedure: binary.BigEndian.Uint32(buf[8:12]),
+		Type:      binary.BigEndian.Uint32(buf[12:16]),
+		Serial:    int32(binary.BigEndian.Uint32(buf[16:20])),
+		Status:    binary.BigEndian.Uint32(buf[20:24]),
+	}, nil
+}
+
+// SendPacket sends a packet to libvirt on the socket connection.
+func (s Socket) SendPacket(
+	serial int32,
+	proc uint32,
+	program uint32,
+	payload []byte,
+	typ uint32,
+	status uint32,
+) error {
+	p := packet{
+		Header: Header{
+			Program:   program,
+			Version:   constants.ProtocolVersion,
+			Procedure: proc,
+			Type:      typ,
+			Serial:    serial,
+			Status:    status,
+		},
+	}
+
+	size := int(unsafe.Sizeof(p.Len)) + int(unsafe.Sizeof(p.Header))
+	if payload != nil {
+		size += len(payload)
+	}
+	p.Len = uint32(size)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.isDisconnected() {
+		// this mirrors what a lot of net code return on use of a no
+		// longer valid connection
+		return syscall.EINVAL
+	}
+
+	err := binary.Write(s.writer, binary.BigEndian, p)
+	if err != nil {
+		return err
+	}
+
+	// write payload
+	if payload != nil {
+		err = binary.Write(s.writer, binary.BigEndian, payload)
+		if err != nil {
+			return err
+		}
+	}
+
+	return s.writer.Flush()
+}
+
+// SendStream sends a stream of packets to libvirt on the socket connection.
+func (s Socket) SendStream(serial int32, proc uint32, program uint32,
+	stream io.Reader, abort chan bool) error {
+	// Keep total packet length under 4 MiB to follow possible limitation in libvirt server code
+	buf := make([]byte, 4*MiB-unsafe.Sizeof(_p))
+	for {
+		select {
+		case <-abort:
+			return s.SendPacket(serial, proc, program, nil, Stream, StatusError)
+		default:
+		}
+		n, err := stream.Read(buf)
+		if n > 0 {
+			err2 := s.SendPacket(serial, proc, program, buf[:n], Stream, StatusContinue)
+			if err2 != nil {
+				return err2
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				return s.SendPacket(serial, proc, program, nil, Stream, StatusOK)
+			}
+			// keep original error
+			err2 := s.SendPacket(serial, proc, program, nil, Stream, StatusError)
+			if err2 != nil {
+				return err2
+			}
+			return err
+		}
+	}
+}

--- a/socket/socket.go
+++ b/socket/socket.go
@@ -109,8 +109,8 @@ type Header struct {
 }
 
 // New initializes a new type for managing the Socket.
-func New(conn net.Conn, router Router) Socket {
-	s := Socket{
+func New(conn net.Conn, router Router) *Socket {
+	s := &Socket{
 		router: router,
 		mu:     &sync.Mutex{},
 	}
@@ -132,7 +132,7 @@ func New(conn net.Conn, router Router) Socket {
 
 // Disconnect closes the Socket connection to libvirt and waits for the reader
 // gorouting to shut down.
-func (s Socket) Disconnect() error {
+func (s *Socket) Disconnect() error {
 	// just return if we're already disconnected
 	if s.isDisconnected() {
 		return nil
@@ -159,13 +159,13 @@ func (s Socket) Disconnect() error {
 // Disconnected returns a channel that will be closed once the current
 // connection is closed.  This can happen due to an explicit call to Disconnect
 // from the client, or due to non-temporary Read or Write errors encountered.
-func (s Socket) Disconnected() <-chan struct{} {
+func (s *Socket) Disconnected() <-chan struct{} {
 	return s.disconnected
 }
 
 // isDisconnected is a non-blocking function to query whether a connection
 // is disconnected or not.
-func (s Socket) isDisconnected() bool {
+func (s *Socket) isDisconnected() bool {
 	select {
 	case <-s.disconnected:
 		return true
@@ -176,7 +176,7 @@ func (s Socket) isDisconnected() bool {
 
 // listenAndRoute reads packets from the Socket and calls the provided
 // Router function to route them
-func (s Socket) listenAndRoute() {
+func (s *Socket) listenAndRoute() {
 	// only returns once it detects a non-temporary error related to the
 	// underlying connection
 	listen(s.reader, s.router)
@@ -276,7 +276,7 @@ func extractHeader(r io.Reader) (*Header, error) {
 }
 
 // SendPacket sends a packet to libvirt on the socket connection.
-func (s Socket) SendPacket(
+func (s *Socket) SendPacket(
 	serial int32,
 	proc uint32,
 	program uint32,
@@ -327,7 +327,7 @@ func (s Socket) SendPacket(
 }
 
 // SendStream sends a stream of packets to libvirt on the socket connection.
-func (s Socket) SendStream(serial int32, proc uint32, program uint32,
+func (s *Socket) SendStream(serial int32, proc uint32, program uint32,
 	stream io.Reader, abort chan bool) error {
 	// Keep total packet length under 4 MiB to follow possible limitation in libvirt server code
 	buf := make([]byte, 4*MiB-unsafe.Sizeof(_p))

--- a/socket/socket_test.go
+++ b/socket/socket_test.go
@@ -1,0 +1,60 @@
+package socket
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/digitalocean/go-libvirt/internal/constants"
+)
+
+var testHeader = []byte{
+	0x20, 0x00, 0x80, 0x86, // program
+	0x00, 0x00, 0x00, 0x01, // version
+	0x00, 0x00, 0x00, 0x01, // procedure
+	0x00, 0x00, 0x00, 0x00, // type
+	0x00, 0x00, 0x00, 0x00, // serial
+	0x00, 0x00, 0x00, 0x00, // status
+}
+
+func TestPktLen(t *testing.T) {
+	data := []byte{0x00, 0x00, 0x00, 0xa} // uint32:10
+	r := bytes.NewBuffer(data)
+
+	expected := uint32(10)
+	actual, err := pktlen(r)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if expected != actual {
+		t.Errorf("expected packet length %q, got %q", expected, actual)
+	}
+}
+
+func TestExtractHeader(t *testing.T) {
+	r := bytes.NewBuffer(testHeader)
+	h, err := extractHeader(r)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if h.Program != constants.Program {
+		t.Errorf("expected Program %q, got %q", constants.Program, h.Program)
+	}
+
+	if h.Version != constants.ProtocolVersion {
+		t.Errorf("expected version %q, got %q", constants.ProtocolVersion, h.Version)
+	}
+
+	if h.Procedure != constants.ProcConnectOpen {
+		t.Errorf("expected procedure %q, got %q", constants.ProcConnectOpen, h.Procedure)
+	}
+
+	if h.Type != Call {
+		t.Errorf("expected type %q, got %q", Call, h.Type)
+	}
+
+	if h.Status != StatusOK {
+		t.Errorf("expected status %q, got %q", StatusOK, h.Status)
+	}
+}

--- a/socket/units.go
+++ b/socket/units.go
@@ -15,7 +15,7 @@
 // This module provides different units of measurement to make other
 // code more readable.
 
-package libvirt
+package socket
 
 const (
 	// B - byte


### PR DESCRIPTION
This change is mostly a reorganizing of code in preparation to break the external API such that we can take a Dialer as input and allow clients to use a single Libvirt object to potentially connect/disconnect/reconnect multiple times.

For now, this just tries to abstract the details around the packet level reading/writing over the socket connection to libvirt into its own type.

NOTE:  I'll add a comment to show what I mean, but there's some exported constants that I moved from the top level libvirt package to the socket package.  I don't know why they are exported or if there's a risk that any clients might be referencing them.