### PR TITLE
fix some stream problems

### DIFF
--- a/internal/event/stream.go
+++ b/internal/event/stream.go
@@ -14,7 +14,13 @@
 
 package event
 
-import "context"
+import (
+	"context"
+)
+
+type emptyEvent struct{}
+
+func (emptyEvent) GetCallbackID() int32 { return 0 }
 
 // Stream is an unbounded buffered event channel. The implementation
 // consists of a pair of unbuffered channels and a goroutine to manage them.
@@ -28,11 +34,19 @@ type Stream struct {
 
 	// manage unbounded channel behavior.
 	queue   []Event
-	peek    chan []Event
+	qlen    chan (chan int)
 	in, out chan Event
 
 	// terminates processing
 	shutdown context.CancelFunc
+}
+
+func (s *Stream) Len() int {
+	// Send a request to the process() loop to get the current length of the
+	// queue
+	ch := make(chan int)
+	s.qlen <- ch
+	return <-ch
 }
 
 // Recv returns the next available event from the Stream's queue.
@@ -45,9 +59,9 @@ func (s *Stream) Push(e Event) {
 	s.in <- e
 }
 
-// Shutdown gracefully terminates Stream processing, releasing all
-// internal resources. Events which have not yet been received by the client
-// will be dropped. Subsequent calls to Shutdown() are idempotent.
+// Shutdown gracefully terminates Stream processing, releasing all internal
+// resources. Events which have not yet been received by the client will be
+// dropped. Subsequent calls to Shutdown() are idempotent.
 func (s *Stream) Shutdown() {
 	if s.shutdown != nil {
 		s.shutdown()
@@ -66,72 +80,45 @@ func (s *Stream) start() context.CancelFunc {
 }
 
 // process manages an Stream's lifecycle until canceled by the provided
-// context.  Incoming events are appended to a queue which is then relayed to
+// context. Incoming events are appended to a queue which is then relayed to
 // the a listening client. New events pushed onto the queue will not block due
 // to client behavior.
 func (s *Stream) process(ctx context.Context) {
+	// Close the output channel so that clients know this stream is finished.
+	// We don't close s.in to avoid creating a race with the stream's Push()
+	// function.
+	defer close(s.out)
+
 	for {
-		// informs send() to stop trying
-		nctx, next := context.WithCancel(ctx)
-		defer next()
+		// This loop relies on the fact that a send to a nil channel will block
+		// forever. If we have no entries in the queue, we set the send channel
+		// to nil, so the clause that attempts to send an event to the client
+		// will never complete. Clients will never receive an emptyEvent.
+		sendCh := chan Event(nil)
+		next := Event(emptyEvent{})
+
+		if len(s.queue) > 0 {
+			sendCh = s.out
+			next = s.queue[0]
+		}
 
 		select {
 		// new event received, append to queue
 		case e := <-s.in:
 			s.queue = append(s.queue, e)
 
-		// safe internal queue lookup
-		case s.peek <- s.queue:
+		case lenCh := <-s.qlen:
+			lenCh <- len(s.queue)
 
 		// client received an event, pop from queue
-		case <-s.send(nctx):
-			if len(s.queue) > 1 {
-				s.queue = s.queue[1:]
-			} else {
-				s.queue = []Event{}
-			}
+		case sendCh <- next:
+			s.queue = s.queue[1:]
 
 		// shutdown requested
 		case <-ctx.Done():
 			return
-
 		}
-
-		next()
 	}
-}
-
-// send returns a channel which blocks until either the first item on the queue
-// (if existing) is sent to the client, or the provided context is canceled.
-// The stream's queue is never modified.
-func (s *Stream) send(ctx context.Context) <-chan struct{} {
-	ch := make(chan struct{})
-
-	go func() {
-		defer close(ch)
-
-		var q []Event
-
-		// safely grab the current event queue
-		// if the queue is empty, block until canceled
-		select {
-		case q = <-s.peek:
-			if len(q) == 0 {
-				<-ctx.Done()
-				return
-			}
-		case <-ctx.Done():
-			return
-		}
-
-		// event(s) available, attempt to send
-		select {
-		case s.out <- q[0]:
-		case <-ctx.Done():
-		}
-	}()
-
-	return ch
 }
 
 // NewStream configures a new Event Stream. Incoming events are appended to a
@@ -139,15 +126,17 @@ func (s *Stream) send(ctx context.Context) <-chan struct{} {
 // not cause incoming events to block. It is the responsibility of the caller
 // to terminate the Stream via Shutdown() when no longer in use.
 func NewStream(program uint32, cbID int32) *Stream {
-	ic := &Stream{
+	s := &Stream{
 		Program:    program,
 		CallbackID: cbID,
 		in:         make(chan Event),
 		out:        make(chan Event),
-		peek:       make(chan []Event),
+		qlen:       make(chan (chan int)),
 	}
 
-	ic.shutdown = ic.start()
+	// Start the processing loop, which will return a routine we can use to
+	// shut the queue down later.
+	s.shutdown = s.start()
 
-	return ic
+	return s
 }

--- a/internal/event/stream_test.go
+++ b/internal/event/stream_test.go
@@ -1,0 +1,85 @@
+package event
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testEvent struct{ id int32 }
+
+func (e testEvent) GetCallbackID() int32 {
+	return e.id
+}
+
+func testEvents(count int) []Event {
+	ev := make([]Event, count)
+
+	for i := 0; i < count; i++ {
+		ev[i] = testEvent{int32(i)}
+	}
+
+	return ev
+}
+
+// TestStreamSequential tests the stream objects by first writing some entries
+// the stream, then reading them back.
+func TestStreamSequential(t *testing.T) {
+	const evCount = 100000
+
+	s := NewStream(1, 2)
+	defer s.Shutdown()
+	events := testEvents(evCount)
+
+	// send a bunch of "events", and make sure we receive them all.
+	fmt.Println("sending test events to queue")
+	for i, e := range events {
+		assert.Equal(t, int32(i), e.GetCallbackID())
+		s.Push(e)
+		assert.Equal(t, i+1, s.Len())
+	}
+
+	assert.Equal(t, evCount, s.Len())
+
+	fmt.Println("reading events from queue")
+	for _, e := range events {
+		qe, ok := <-s.Recv()
+		assert.True(t, ok)
+		assert.Equal(t, e, qe)
+	}
+
+	assert.Zero(t, s.Len())
+}
+
+// TestStreamParallel tests the stream object with a pair of goroutines, one
+// writing to the queue, the other reading from it.
+func TestStreamParallel(t *testing.T) {
+	const evCount = 10000
+
+	s := NewStream(1, 2)
+	defer s.Shutdown()
+	events := testEvents(evCount)
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	// Start 2 goroutines, one to send, the other to receive.
+	go func() {
+		defer wg.Done()
+		for _, e := range events {
+			s.Push(e)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < evCount; i++ {
+			e := <-s.Recv()
+			assert.Equal(t, int32(i), e.GetCallbackID())
+		}
+	}()
+
+	wg.Wait()
+	assert.Zero(t, s.Len())
+}

--- a/libvirt.go
+++ b/libvirt.go
@@ -224,7 +224,7 @@ func (l *Libvirt) SubscribeQEMUEvents(ctx context.Context, dom string) (<-chan D
 		defer cancel()
 		defer l.unsubscribeQEMUEvents(stream)
 		defer stream.Shutdown()
-		defer func() { close(ch) }()
+		defer close(ch)
 
 		for {
 			select {


### PR DESCRIPTION
The queue we use for streams had a couple of problems, and was overly
complex. Simplify the queue processor, and add unit tests for this file.