### PR TITLE
take dialer as input instead of already existing connection

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -694,7 +694,6 @@ func NewWithDialer(dialer socket.Dialer) *Libvirt {
 		events:       make(map[int32]*event.Stream),
 	}
 
-	//
 	l.socket = socket.New(dialer, l)
 
 	// we start with a closed channel since that indicates no connection

--- a/libvirt_test.go
+++ b/libvirt_test.go
@@ -25,15 +25,19 @@ import (
 	"github.com/digitalocean/go-libvirt/libvirttest"
 )
 
-func TestConnect(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+func TestConnectAndDisconnect(t *testing.T) {
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = l.Disconnect()
+	if err != nil {
 		t.Error(err)
 	}
-	defer l.Disconnect()
 }
 
 func TestLibvirt_ConnectToURI(t *testing.T) {
@@ -62,8 +66,8 @@ func TestLibvirt_ConnectToURI(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			conn := libvirttest.New()
-			libvirtConn := New(conn)
+			dialer := libvirttest.New()
+			libvirtConn := New(dialer)
 
 			if err := libvirtConn.ConnectToURI(tt.args.uri); (err != nil) != tt.wantErr {
 				t.Errorf("ConnectToURI() error = %v, wantErr %v", err, tt.wantErr)
@@ -73,19 +77,9 @@ func TestLibvirt_ConnectToURI(t *testing.T) {
 	}
 }
 
-func TestDisconnect(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
-
-	err := l.Disconnect()
-	if err != nil {
-		t.Error(err)
-	}
-}
-
 func TestDisconnectCleanup(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -113,8 +107,8 @@ func TestDisconnectCleanup(t *testing.T) {
 }
 
 func TestLostConnectionCleanup(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -128,7 +122,7 @@ func TestLostConnectionCleanup(t *testing.T) {
 	// forcibly just close the fake libvirt tester side of the pipe to lose
 	// the connection.
 	// This should be detected and cleaned up without having to call Disconnect.
-	conn.Test.Close()
+	dialer.Test.Close()
 
 	// now make sure that deregistered the callback
 	// do it via a select just to avoid the 10 minute unit test timeout on
@@ -142,8 +136,8 @@ func TestLostConnectionCleanup(t *testing.T) {
 }
 
 func TestMigrate(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -171,8 +165,8 @@ func TestMigrate(t *testing.T) {
 }
 
 func TestMigrateSetMaxSpeed(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -191,8 +185,8 @@ func TestMigrateSetMaxSpeed(t *testing.T) {
 }
 
 func TestDomains(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -225,8 +219,8 @@ func TestDomains(t *testing.T) {
 }
 
 func TestDomainState(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -246,8 +240,8 @@ func TestDomainState(t *testing.T) {
 }
 
 func TestDomainMemoryStats(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -288,8 +282,8 @@ func TestDomainMemoryStats(t *testing.T) {
 }
 
 func TestEvents(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -336,7 +330,7 @@ func TestEvents(t *testing.T) {
 	}()
 
 	// send an event to the listener goroutine
-	conn.Test.Write(append(testEventHeader, testEvent...))
+	dialer.Test.Write(append(testEventHeader, testEvent...))
 
 	// wait for completion
 	if err := <-done; err != nil {
@@ -345,8 +339,8 @@ func TestEvents(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -383,9 +377,9 @@ func TestRun(t *testing.T) {
 }
 
 func TestRunFail(t *testing.T) {
-	conn := libvirttest.New()
-	conn.Fail = true
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
+	dialer.Fail = true
 
 	err := l.Connect()
 	if err != nil {
@@ -400,8 +394,8 @@ func TestRunFail(t *testing.T) {
 }
 
 func TestSecrets(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -442,8 +436,8 @@ func TestSecrets(t *testing.T) {
 }
 
 func TestStoragePool(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -474,8 +468,8 @@ func TestStoragePool(t *testing.T) {
 }
 
 func TestStoragePools(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -512,8 +506,8 @@ func TestStoragePools(t *testing.T) {
 }
 
 func TestStoragePoolRefresh(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -532,8 +526,8 @@ func TestStoragePoolRefresh(t *testing.T) {
 }
 
 func TestUndefine(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -548,8 +542,8 @@ func TestUndefine(t *testing.T) {
 }
 
 func TestDestroy(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -564,8 +558,8 @@ func TestDestroy(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -585,8 +579,8 @@ func TestVersion(t *testing.T) {
 }
 
 func TestDefineXML(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -602,8 +596,8 @@ func TestDefineXML(t *testing.T) {
 }
 
 func TestDomainCreateWithFlags(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -622,8 +616,8 @@ func TestDomainCreateWithFlags(t *testing.T) {
 }
 
 func TestShutdown(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -638,8 +632,8 @@ func TestShutdown(t *testing.T) {
 }
 
 func TestReboot(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -654,8 +648,8 @@ func TestReboot(t *testing.T) {
 }
 
 func TestReset(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -669,8 +663,8 @@ func TestReset(t *testing.T) {
 }
 
 func TestSetBlockIOTune(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -684,8 +678,8 @@ func TestSetBlockIOTune(t *testing.T) {
 }
 
 func TestGetBlockIOTune(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -707,8 +701,8 @@ func TestGetBlockIOTune(t *testing.T) {
 // ConnectGetAllDomainStats is a good test, since its return values include an
 // array of TypedParams embedded in a struct.
 func TestConnectGetAllDomainStats(t *testing.T) {
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := New(dialer)
 
 	err := l.Connect()
 	if err != nil {

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -271,8 +271,8 @@ func TestAddStream(t *testing.T) {
 func TestRemoveStream(t *testing.T) {
 	id := int32(1)
 
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := NewWithDialer(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -300,8 +300,8 @@ func TestRemoveAllStreams(t *testing.T) {
 	id1 := int32(1)
 	id2 := int32(2)
 
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := NewWithDialer(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -381,8 +381,8 @@ func TestSerial(t *testing.T) {
 func TestLookup(t *testing.T) {
 	name := "test"
 
-	conn := libvirttest.New()
-	l := New(conn)
+	dialer := libvirttest.New()
+	l := NewWithDialer(dialer)
 
 	err := l.Connect()
 	if err != nil {
@@ -401,10 +401,10 @@ func TestLookup(t *testing.T) {
 }
 
 func TestDeregisterAll(t *testing.T) {
-	conn := libvirttest.New()
+	dialer := libvirttest.New()
 	c1 := make(chan response)
 	c2 := make(chan response)
-	l := New(conn)
+	l := NewWithDialer(dialer)
 	if len(l.callbacks) != 0 {
 		t.Error("expected callback map to be empty at test start")
 	}

--- a/socket/dialers/already_connected.go
+++ b/socket/dialers/already_connected.go
@@ -1,0 +1,26 @@
+package dialers
+
+import (
+	"net"
+)
+
+// AlreadyConnected implements a dialer interface for a connection that was
+// established prior to initializing the socket object.  This exists solely
+// for backwards compatability with the previous implementation of Libvirt
+// that took an already established connection.
+type AlreadyConnected struct {
+	c net.Conn
+}
+
+// NewAlreadyConnected is a noop dialer to simply use a connection previously
+// established.  This means any re-dial attempts simply won't work.
+func NewAlreadyConnected(c net.Conn) AlreadyConnected {
+	return AlreadyConnected{c}
+}
+
+// Dial just returns the connection previously established.
+// If at some point it is disconnected by the client, this obviously does *not*
+// re-dial and will simply return the already closed connection.
+func (a AlreadyConnected) Dial() (net.Conn, error) {
+	return a.c, nil
+}

--- a/socket/dialers/local.go
+++ b/socket/dialers/local.go
@@ -1,0 +1,57 @@
+package dialers
+
+import (
+	"net"
+	"time"
+)
+
+const (
+	// defaultSocket specifies the default path to the libvirt unix socket.
+	defaultSocket = "/var/run/libvirt/libvirt-sock"
+
+	// defaultLocalTimeout specifies the default libvirt dial timeout.
+	defaultLocalTimeout = 15 * time.Second
+)
+
+// Local implements connecting to a local libvirtd over the unix socket.
+type Local struct {
+	timeout time.Duration
+	socket  string
+}
+
+// LocalOption is a function for setting local socket options.
+type LocalOption func(*Local)
+
+// WithLocalTimeout sets the dial timeout.
+func WithLocalTimeout(timeout time.Duration) LocalOption {
+	return func(l *Local) {
+		l.timeout = timeout
+	}
+}
+
+// WithSocket sets the path to the local libvirt socket.
+func WithSocket(socket string) LocalOption {
+	return func(l *Local) {
+		l.socket = socket
+	}
+}
+
+// NewLocal is a default dialer to simply connect to a locally running libvirt's
+// socket.
+func NewLocal(opts ...LocalOption) *Local {
+	l := &Local{
+		timeout: defaultLocalTimeout,
+		socket:  defaultSocket,
+	}
+
+	for _, opt := range opts {
+		opt(l)
+	}
+
+	return l
+}
+
+// Dial connects to a local socket
+func (l *Local) Dial() (net.Conn, error) {
+	return net.DialTimeout("unix", l.socket, l.timeout)
+}

--- a/socket/dialers/remote.go
+++ b/socket/dialers/remote.go
@@ -1,0 +1,61 @@
+package dialers
+
+import (
+	"net"
+	"time"
+)
+
+const (
+	// defaultRemotePort specifies the default libvirtd port.
+	defaultRemotePort = "16509"
+
+	// defaultRemoteTimeout specifies the default libvirt dial timeout.
+	defaultRemoteTimeout = 20 * time.Second
+)
+
+// Remote implements connecting to a remote server's libvirt using tcp
+type Remote struct {
+	timeout    time.Duration
+	host, port string
+}
+
+// RemoteOption is a function for setting remote dialer options.
+type RemoteOption func(*Remote)
+
+// WithRemoteTimeout sets the dial timeout.
+func WithRemoteTimeout(timeout time.Duration) RemoteOption {
+	return func(r *Remote) {
+		r.timeout = timeout
+	}
+}
+
+// UsePort sets the port to dial for libirt on the target host server.
+func UsePort(port string) RemoteOption {
+	return func(r *Remote) {
+		r.port = port
+	}
+}
+
+// NewRemote is a dialer for connecting to libvirt running on another server.
+func NewRemote(hostAddr string, opts ...RemoteOption) *Remote {
+	r := &Remote{
+		timeout: defaultRemoteTimeout,
+		host:    hostAddr,
+		port:    defaultRemotePort,
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
+}
+
+// Dial connects to libvirt running on another server.
+func (r *Remote) Dial() (net.Conn, error) {
+	return net.DialTimeout(
+		"tcp",
+		net.JoinHostPort(r.host, r.port),
+		r.timeout,
+	)
+}

--- a/socket/socket.go
+++ b/socket/socket.go
@@ -14,7 +14,7 @@ import (
 	"github.com/digitalocean/go-libvirt/internal/constants"
 )
 
-const disconnectTimeout = 5*time.Second
+const disconnectTimeout = 5 * time.Second
 
 // request and response statuses
 const (
@@ -56,6 +56,11 @@ const (
 	ReplyWithFDs
 )
 
+// Dialer is an interface for connecting to libvirt's underlying socket.
+type Dialer interface {
+	Dial() (net.Conn, error)
+}
+
 // Router is an interface used to route packets to the appropriate clients.
 type Router interface {
 	Route(*Header, []byte)
@@ -63,6 +68,7 @@ type Router interface {
 
 // Socket represents a libvirt Socket and its connection state
 type Socket struct {
+	dialer Dialer
 	router Router
 
 	conn   net.Conn
@@ -109,10 +115,30 @@ type Header struct {
 }
 
 // New initializes a new type for managing the Socket.
-func New(conn net.Conn, router Router) *Socket {
+func New(dialer Dialer, router Router) *Socket {
 	s := &Socket{
-		router: router,
-		mu:     &sync.Mutex{},
+		dialer:       dialer,
+		router:       router,
+		disconnected: make(chan struct{}),
+		mu:           &sync.Mutex{},
+	}
+
+	// we start with a closed channel since that indicates no connection
+	close(s.disconnected)
+
+	return s
+}
+
+func (s *Socket) Connect() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.conn != nil {
+		return errors.New("already connected to socket")
+	}
+	conn, err := s.dialer.Dial()
+	if err != nil {
+		return err
 	}
 
 	s.conn = conn
@@ -120,12 +146,9 @@ func New(conn net.Conn, router Router) *Socket {
 	s.writer = bufio.NewWriter(conn)
 	s.disconnected = make(chan struct{})
 
-	// TODO:  The connection and listen goroutine should be moved to the
-	//  Connect function, but this is going to impact the exported API, so
-	//  trying to do as much as possible before doing that.
 	go s.listenAndRoute()
 
-	return s
+	return nil
 }
 
 // Disconnect closes the Socket connection to libvirt and waits for the reader


### PR DESCRIPTION
This is a step in the direction of allowing go-libvirt to manage the underlying physical connection instead of tying the lifetime of the Libvirt object to the lifetime of the passed in connection.

For now, all this does is allow a client to call NewWithDialer, and deprecates the existing New function.  Using NewWithDialer allows the Libvirt Connect/Disconnect functions to be called multiple times.  It also adds two basic dialer implementations for local socket and tcp.

The New function was marked as deprecated, but for now uses a basically no-op dialer that just uses the passed in connection. 