### PR TITLE
Enable go-libvirt generation for newer libvirt distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,15 @@ re-run the code generator. To do this, follow these steps:
 
 - First, download a copy of the libvirt sources corresponding to the version you
   want to use.
-- Next, run `autogen.sh` in the libvirt directory. The autotools will check for
-  necessary libraries and prepare libvirt for building. We don't actually need
-  to build libvirt, but we do require some header files that are produced in
-  this step.
+- Change directories into where you've unpacked your distribution of libvirt.
+- The second step depends on the version of libvirt you'd like to build against.
+  It's not necessary to actually build libvirt, but it is necessary to run libvirt's
+  "configure" step because it generates required files.
+  - For libvirt < v6.7.0:
+    - `$ mkdir build; cd build`
+    - `$ ../autogen.sh`
+  - For libvirt >= v6.7.0:
+    - `$ meson setup build`
 - Finally, set the environment variable `LIBVIRT_SOURCE` to the directory you
   put libvirt into, and run `go generate ./...` from the go-libvirt directory.
   This runs both of the go-libvirt's code generators.

--- a/libvirt.yml
+++ b/libvirt.yml
@@ -27,7 +27,7 @@ PARSER:
     # rely on our caller to link the libvirt source directory to lv_source/, and
     # run on that code. This isn't ideal, but changes to c-for-go are needed to
     # fix it.
-    IncludePaths: [./lv_source/include]
+    IncludePaths: [./lv_source/include, ./lv_source/build/include]
     SourcesPaths:
         - libvirt/libvirt.h
         - libvirt/virterror.h


### PR DESCRIPTION
There are a few changes that seem to be backwards compatible for generating go-libvirt from newer and older libvirt distributions.

To summarize:

* libvirt moved to a new build system generator called meson and so the `autogen.sh` setup instructions won't work for newer libvirt distributions. I've added instructions for using `meson` to run the configure step.
* libvirt generates the libvirt-common.h header at configure-time and it seems for newer versions of libvirt, even for autotools or the newer meson-based build system, that the output is placed under the build folder in an include directory. I've updated the c-to-go thing to include that as a search path.

I tested with libvirt v8.2.0 (newest), v6.7.0 (first release with meson (?)), and v6.6.0 (autotools) and made sure that `go generate ./...` and `go test ./...` passed without any issues.