### PR TITLE
expose Libvirt.Disconnected method

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -228,6 +228,13 @@ func (l *Libvirt) Disconnect() error {
 	return err
 }
 
+// Disconnected allows callers to detect if the underlying connection
+// to libvirt has been closed. If the returned channel is closed, then
+// the connection to libvirt has been lost (or disconnected intentionally).
+func (l *Libvirt) Disconnected() <-chan struct{} {
+	return l.disconnected
+}
+
 // Domains returns a list of all domains managed by libvirt.
 //
 // Deprecated: use ConnectListAllDomains instead.

--- a/libvirt_test.go
+++ b/libvirt_test.go
@@ -154,6 +154,40 @@ func TestLostConnectionCleanup(t *testing.T) {
 	}
 }
 
+func TestMonitorDisconnect(t *testing.T) {
+	dialer := libvirttest.New()
+	lv := NewWithDialer(dialer)
+
+	// Haven't connected yet.
+	select {
+	case <-lv.Disconnected():
+	default:
+		t.Fatalf("chan is open but should be closed")
+	}
+
+	err := lv.Connect()
+	if err != nil {
+		t.Fatalf("connect failed: %v", err)
+	}
+
+	select {
+	case <-lv.Disconnected():
+		t.Fatalf("chan should be open but is closed")
+	default:
+	}
+
+	err = lv.Disconnect()
+	if err != nil {
+		t.Fatalf("disconnect failed: %v", err)
+	}
+
+	select {
+	case <-lv.Disconnected():
+	default:
+		t.Fatalf("chan still open after Disconnect")
+	}
+}
+
 func TestMigrate(t *testing.T) {
 	dialer := libvirttest.New()
 	l := NewWithDialer(dialer)


### PR DESCRIPTION
Fixes #149 

This allows client code to monitor and react when the underlying
libvirt connection transitions into a disconnected state.