### PR TITLE
libvirttest: use atomic to read "serial"

### DIFF
--- a/libvirttest/libvirt.go
+++ b/libvirttest/libvirt.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The go-libvirt Authors.
+// Copyright 2022 The go-libvirt Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -708,8 +708,7 @@ func (m *MockLibvirt) handleQEMU(procedure uint32, conn net.Conn) {
 // reply automatically injects the correct serial
 // number into the provided response buffer.
 func (m *MockLibvirt) reply(buf []byte) []byte {
-	atomic.AddUint32(&m.serial, 1)
-	binary.BigEndian.PutUint32(buf[20:24], m.serial)
-
+	serial := atomic.AddUint32(&m.serial, 1)
+	binary.BigEndian.PutUint32(buf[20:24], serial)
 	return buf
 }


### PR DESCRIPTION
Otherwise it's a racy read:

WARNING: DATA RACE
Write at 0x0000008cb434 by goroutine 71:
  encoding/binary.bigEndian.PutUint32()
      /usr/local/go/src/encoding/binary/binary.go:118 +0x124
  github.com/digitalocean/go-libvirt/libvirttest.(*MockLibvirt).reply()
      /home/ckuehl/src/go-libvirt/libvirttest/libvirt.go:712 +0xce
  github.com/digitalocean/go-libvirt/libvirttest.(*MockLibvirt).handleQEMU()
      /home/ckuehl/src/go-libvirt/libvirttest/libvirt.go:698 +0x35
  github.com/digitalocean/go-libvirt/libvirttest.(*MockLibvirt).handle()
      /home/ckuehl/src/go-libvirt/libvirttest/libvirt.go:633 +0x1a4
  github.com/digitalocean/go-libvirt/libvirttest.(*MockLibvirt).Dial.func1()
      /home/ckuehl/src/go-libvirt/libvirttest/libvirt.go:609 +0x50

Previous write at 0x0000008cb434 by goroutine 69:
  [failed to restore the stack]