### PR TITLE
integration: wait for Disconnected before assert

### DIFF
--- a/libvirt_integration_test.go
+++ b/libvirt_integration_test.go
@@ -170,6 +170,8 @@ func TestLostConnection(t *testing.T) {
 	// forcibly close the connection out from under the Libvirt object
 	conn.Close()
 
+	<-l.Disconnected()
+
 	// this should return an error about the connection being lost
 	_, err := l.DomainLookupByName(testDomainName)
 	if err == nil {


### PR DESCRIPTION
There's an unavoidable race here if we don't:

```
+---------+       +---------+                              +---------------+                           +---------------+                          +---------+
| Client  |       | Libvirt |                              | socketRouter  |                           | socketWriter  |                          | netConn |
+---------+       +---------+                              +---------------+                           +---------------+                          +---------+
     |                 |                                           |                                           |                                       | ------------------\
     |                 |                                           |                                           |                                       |-| connection lost |
     |                 |                                           |                                           |                                       | |-----------------|
     |                 |                                           |                                           |                                       |
     | Disconnect      |                                           |                                           |                                       |
     |---------------->|                                           |                                           |                                       |
     |                 |                                           |                                           |                                       |
     |                 | Send Disconnect packet                    |                                           |                                       |
     |                 |-------------------------------------------------------------------------------------->|                                       |
     |                 |                                           |                                           | --------------------------\           |
     |                 |                                           |                                           |-| isDisconnected == false |           |
     |                 |                                           |                                           | |-------------------------|           |
     |                 |                                           |                                           |                                       |
     |                 |                                           |                                           |                      EINVAL/EPIPE/EOF |
     |                 |                                           |<----------------------------------------------------------------------------------|
     |                 |                                           |                                           |                                       |
     |                 |                                           |                                           | Write disconnect packet               |
     |                 |                                           |                                           |-------------------------------------->|
     |                 |                                           |                                           |                                       |
     |                 |                                           | listener closes disconnected chan         |                                       |
     |                 |                                           |----------------------------------         |                                       |
     |                 |                                           |                                 |         |                                       |
     |                 |                                           |<---------------------------------         |                                       |
     |                 |                                           |                                           |                                       |
     |                 |                                           |                                           |      [x] ERROR (non-EINVAL/EPIPE/EOF) |
     |                 |                                           |                                           |<--------------------------------------|
     |                 |                                           |                                           |                                       |
     |                 |                                           |                                 [x] ERROR |                                       |
     |                 |<--------------------------------------------------------------------------------------|                                       |
     |                 | ----------------------------------\       |                                           |                                       |
     |                 |-| err != syscall.EINVAL/EPIPE/EOF |       |                                           |                                       |
     |                 | |---------------------------------|       |                                           |                                       |
     |                 |                                           |                                           |                                       |
     |       [x] ERROR |                                           |                                           |                                       |
     |<----------------|                                           |                                           |                                       |
```

It looks like this race is what caused one of the previously merged commits to fail CI on the main branch.