### PR TITLE
integration: fix failure when there is >1 pool

### DIFF
--- a/libvirt_integration_test.go
+++ b/libvirt_integration_test.go
@@ -296,16 +296,15 @@ func TestStoragePoolsIntegration(t *testing.T) {
 		t.Error(err)
 	}
 
-	wantLen := 1
-	gotLen := len(pools)
-	if gotLen != wantLen {
-		t.Fatalf("expected %d storage pool, got %d", wantLen, gotLen)
+	found := make(map[string]struct{})
+	for _, pool := range pools {
+		found[pool.Name] = struct{}{}
 	}
 
-	wantName := "test"
-	gotName := pools[0].Name
-	if gotName != wantName {
-		t.Errorf("expected name %q, got %q", wantName, gotName)
+	want := "test"
+	_, ok := found[want]
+	if !ok {
+		t.Errorf("did not find %q in %v", want, found)
 	}
 }
 


### PR DESCRIPTION
This will spuriously fail on a developer's machine unless they purge
their pre-existing libvirt configuration. Instead of assuming the test
is starting from a blank slate, just assert that the thing that the test
expects to be there is there, and nothing else.