### PR TITLE
rpc_test: use Libvirt.addStream to add streams

### DIFF
--- a/rpc_test.go
+++ b/rpc_test.go
@@ -283,7 +283,7 @@ func TestRemoveStream(t *testing.T) {
 	stream := event.NewStream(constants.QEMUProgram, id)
 	defer stream.Shutdown()
 
-	l.events[id] = stream
+	l.addStream(stream)
 
 	fmt.Println("removing stream")
 	err = l.removeStream(id)
@@ -318,12 +318,12 @@ func TestRemoveAllStreams(t *testing.T) {
 	stream := event.NewStream(constants.QEMUProgram, id1)
 	defer stream.Shutdown()
 
-	l.events[id1] = stream
+	l.addStream(stream)
 
 	stream2 := event.NewStream(constants.QEMUProgram, id2)
 	defer stream2.Shutdown()
 
-	l.events[id2] = stream2
+	l.addStream(stream2)
 
 	l.removeAllStreams()
 


### PR DESCRIPTION
These tests invoke Libvirt.Connect and before a successful call to
Libvirt.Connect returns, the underlying socket is "live" and will be
routing messages directly to Libvirt from its goroutine, which means
l.events is a critical section and needs to be accessed with a lock.