### PR TITLE
don't leak MockLibvirt.handle goroutines

### DIFF
--- a/libvirttest/libvirt.go
+++ b/libvirttest/libvirt.go
@@ -18,6 +18,7 @@ package libvirttest
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -620,7 +621,10 @@ func (m *MockLibvirt) handle(conn net.Conn) {
 	for {
 		// packetLengthSize + headerSize
 		buf := make([]byte, 28)
-		conn.Read(buf)
+		_, err := conn.Read(buf)
+		if errors.Is(err, io.EOF) {
+			return
+		}
 
 		// extract program
 		prog := binary.BigEndian.Uint32(buf[4:8])


### PR DESCRIPTION
The Libvirt struct disconnects its underlying socket after it receives a
response to its disconnect packet. As far as MockLibvirt is concerned,
this is where it's expected to stop trying to handle requests; however,
MockLibvirt.handle doesn't have an exit condition.

To fix this, check to see if the conn.Read returns EOF, since that means
the socket has been closed and no more messages are forthcoming. If
that's the case, MockLibvirt.handle should exit.

---

Furthermore, I think these leaked goroutines are cluttering the stacktrace for #167 and I'd like to reduce the noise for when that happens.