### PR TITLE
rpc: detect interrupted socket

### DIFF
--- a/rpc_test.go
+++ b/rpc_test.go
@@ -489,3 +489,12 @@ func TestRouteDeadlock(t *testing.T) {
 	fmt.Println("checking for deadlock after context cancellation")
 	send(0, 50)
 }
+
+func TestGetResponseInterrupted(t *testing.T) {
+	dialer := libvirttest.New()
+	l := NewWithDialer(dialer)
+	c := make(chan response)
+	close(c)
+	_, err := l.getResponse(c)
+	assert.Equal(t, ErrInterrupted, err)
+}


### PR DESCRIPTION
Prior to this commit, if libvirtd crashes while go-libvirt is awaiting a response to a remote procedure call, no error will be returned and the caller might assume the call succeeded.

This commit detects this condition and returns an error to the caller instead.