### PR TITLE
Fix typo in `.github/workflows` and turn into a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Running the Integration Tests
 -----------------------------
 
 Github actions workflows are defined in [.github/workflows](.github/workflows)
-and can be triggered manually in the github GUI after pushing a branch.  There
+and can be triggered manually in the GitHub UI after pushing a branch. There
 are not currently convenient scripts for setting up and running integration tests
 locally, but installing libvirt and defining only the artifacts described by the
 files in testdata should be sufficient to be able to run the integration test file

--- a/README.md
+++ b/README.md
@@ -272,9 +272,9 @@ func main() {
 Running the Integration Tests
 -----------------------------
 
-Github actions workflows are defined in .github/worflows and can be triggered
-manually in the github GUI after pushing a branch.  There are not currently
-convenient scripts for setting up and running integration tests locally, but
-installing libvirt and defining only the artifacts described by the files in
-testdata should be sufficient to be able to run the integration test file against.
-
+Github actions workflows are defined in [.github/workflows](.github/workflows)
+and can be triggered manually in the github GUI after pushing a branch.  There
+are not currently convenient scripts for setting up and running integration tests
+locally, but installing libvirt and defining only the artifacts described by the
+files in testdata should be sufficient to be able to run the integration test file
+against.

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ func main() {
 Running the Integration Tests
 -----------------------------
 
-Github actions workflows are defined in [.github/workflows](.github/workflows)
+GitHub actions workflows are defined in [.github/workflows](.github/workflows)
 and can be triggered manually in the GitHub UI after pushing a branch. There
 are not currently convenient scripts for setting up and running integration tests
 locally, but installing libvirt and defining only the artifacts described by the


### PR DESCRIPTION
Fix typo is `.github/workflows` and turn it into a link.