### PR TITLE
export a convenient Libvirt.IsConnected method

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -241,6 +241,17 @@ func (l *Libvirt) Disconnected() <-chan struct{} {
 	return l.disconnected
 }
 
+// IsConnected indicates whether or not there is currently a connection to
+// libvirtd.
+func (l *Libvirt) IsConnected() bool {
+	select {
+	case <-l.Disconnected():
+		return false
+	default:
+		return true
+	}
+}
+
 // Domains returns a list of all domains managed by libvirt.
 //
 // Deprecated: use ConnectListAllDomains instead.

--- a/libvirt_test.go
+++ b/libvirt_test.go
@@ -832,3 +832,30 @@ func TestConnectGetAllDomainStats(t *testing.T) {
 		t.Fatalf("unexpected typed param value %v", stats[1].Params[1].Value)
 	}
 }
+
+func TestIsConnected(t *testing.T) {
+	dialer := libvirttest.New()
+	l := NewWithDialer(dialer)
+
+	if l.IsConnected() {
+		t.Error("expected IsConnected == false, got true")
+	}
+
+	err := l.Connect()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !l.IsConnected() {
+		t.Error("expected IsConnected == true, got false")
+	}
+
+	err = l.Disconnect()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if l.IsConnected() {
+		t.Error("expected IsConnected == false, got true")
+	}
+}


### PR DESCRIPTION
This reduces the amount of boilerplate required for client code to reference the connection state during error handling code paths, especially if the client code hasn't built a reconnect mechanism around the underlying Libvirt.Disconnected chan.