### PR TITLE
add Ubuntu 22.04 to CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ['ubuntu-18.04', 'ubuntu-20.04']
+        os: ['ubuntu-18.04', 'ubuntu-20.04', 'ubuntu-22.04']
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
18.04 will soon be EOL, and can be removed some time after that happens.