### PR TITLE
ci: use 'oldstable' and 'stable' go toolchain aliases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
   # allow manual execution from the web interface
   workflow_dispatch:
@@ -14,13 +14,14 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-20.04', 'ubuntu-22.04']
+        toolchain: ['oldstable', 'stable']
 
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2 # respository path: $GITHUB_WORKSPACE
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: ${{ matrix.toolchain }}
 
       - name: Install golint
         run: go install golang.org/x/lint/golint@latest


### PR DESCRIPTION
The setup-go action has made maintaining workflows built on it easier by not requiring constant updates as new versions of Go are released.

'stable' is the current stable toolchain, and 'oldstable' is stable-1.

Also, update the branch name to 'main', as this seems to have changed.