### PR TITLE
update ubuntu versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-22.04']
+        os: ['ubuntu-22.04', 'ubuntu-24.04']
         toolchain: ['oldstable', 'stable']
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Ubuntu 20.04 is EOL, so update CI builds to 22.04 and 24.04.